### PR TITLE
Implemented for board of directors, fiance committee and special matt…

### DIFF
--- a/city_scrapers/spiders/ca_highspeed_rail.py
+++ b/city_scrapers/spiders/ca_highspeed_rail.py
@@ -1,0 +1,140 @@
+import re
+from datetime import datetime, timedelta
+from parser import ParserError
+
+from city_scrapers_core.constants import BOARD, COMMITTEE
+from city_scrapers_core.spiders import CityScrapersSpider
+from dateutil.parser import parse
+
+from city_scrapers.items import Meeting
+
+
+class CaHighspeedRailSpider(CityScrapersSpider):
+    name = "ca_highspeed_rail"
+    agency = "California"
+    sub_agency = "High-Speed Rail Authority"
+    timezone = "America/Los_Angeles"
+    start_urls = [
+        "https://hsr.ca.gov/about/board-of-directors/schedule/",
+        "https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/",
+        "https://hsr.ca.gov/about/board-of-directors/special-matters-committee/",
+    ]
+
+    def parse(self, response):
+        # Upcoming meetings
+        for item in response.xpath(
+            "//div[@class='et_pb_module et_pb_text et_pb_text_0  "
+            "et_pb_text_align_left et_pb_bg_layout_light']//li/text()"
+        ).getall():
+            start_date = self._parse_start(item)
+            # If in the future then we yield
+            # (this list could include meetings in the past)
+            if start_date >= datetime.now():
+                meeting = Meeting(
+                    title=self._parse_title(item, response),
+                    description=self._parse_description(item),
+                    classification=self._parse_classification(item, response),
+                    start=start_date,
+                    end=self._parse_end(item),
+                    all_day=self._parse_all_day(item),
+                    time_notes=self._parse_time_notes(item),
+                    location=self._parse_location(item),
+                    links=[],
+                    source=self._parse_source(response),
+                    created=datetime.now(),
+                    updated=datetime.now(),
+                )
+
+                meeting["status"] = self._get_status(meeting)
+                meeting["id"] = self._get_id(meeting)
+
+                yield meeting
+
+        # Archived meetings
+        for item in response.xpath(
+            "//div[contains(@class, 'et_pb_module et_pb_toggle')]"
+        ):
+            meeting = Meeting(
+                title=self._parse_title(item, response),
+                description=self._parse_description(item),
+                classification=self._parse_classification(item, response),
+                start=self._parse_start_archived(item),
+                end=self._parse_end(item),
+                all_day=self._parse_all_day(item),
+                time_notes=self._parse_time_notes(item),
+                location=self._parse_location(item),
+                links=self._parse_links(item),
+                source=self._parse_source(response),
+                created=datetime.now(),
+                updated=datetime.now(),
+            )
+
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+
+            yield meeting
+
+    def _parse_title(self, item, response):
+        if "finance" in response.url:
+            return "Finance & Audit Committee"
+        elif "special" in response.url:
+            return "Special Matters Committee"
+        else:
+            return "Board Meeting"
+
+    def _parse_description(self, item):
+        return ""
+
+    def _parse_classification(self, item, response):
+        if "committee" in response.url:
+            return COMMITTEE
+        else:
+            return BOARD
+
+    def _parse_start(self, item):
+        start_time = timedelta(hours=10)
+        regex_date = r"^.*?\d{4}"
+        date_match = re.search(regex_date, item, re.M)
+        if date_match:
+            try:
+                date = parse(date_match.group().strip()) + start_time
+                return date.replace(tzinfo=None)
+            except ParserError:
+                return None
+
+        return None
+
+    def _parse_start_archived(self, item):
+        date = item.xpath(".//h2/text()").get()
+        return self._parse_start(date)
+
+    def _parse_end(self, item):
+        return None
+
+    def _parse_time_notes(self, item):
+        return ""
+
+    def _parse_all_day(self, item):
+        return False
+
+    def _parse_location(self, item):
+        return {
+            "address": "770 L Street, Suite 620 Sacramento, CA 95814",
+            "name": "California High-Speed Rail Authority",
+        }
+
+    def _parse_links(self, item):
+
+        links = item.xpath(".//a")
+        results = []
+
+        for link in links:
+            link_text = link.xpath(".//text()").get()
+            href = link.xpath(".//@href").get()
+
+            results.append({"title": link_text, "href": href})
+
+        return results
+
+    def _parse_source(self, response):
+        return response.url

--- a/tests/files/ca_highspeed_rail.html
+++ b/tests/files/ca_highspeed_rail.html
@@ -1,0 +1,993 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="Author" content="State of California"/>
+	<meta name="Description" content="State of California"/>
+	<meta name="Keywords" content="California, government"/>
+
+	<!-- http://t.co/dKP3o1e -->
+	<meta name="HandheldFriendly" content="True">
+
+	<!-- for Blackberry, AvantGo -->
+	<meta name="MobileOptimized" content="320">
+
+	<!-- for Windows mobile -->
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+	<!-- Google Meta-->
+	<meta name="google-site-verification" content="001779225245372747843:jso5c-pvxls"/>
+
+	
+	
+	<link rel="apple-touch-icon-precomposed" sizes="100x100" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-precomposed.png">
+	<link rel="apple-touch-icon-precomposed" sizes="192x192" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-192x192.png">
+	<link rel="apple-touch-icon-precomposed" sizes="180x180" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-180x180.png">
+	<link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-152x152.png">
+	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-144x144.png">
+	<link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-120x120.png">
+	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-114x114.png">
+	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon-precomposed" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-57x57.png">
+	<link rel="apple-touch-icon" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon.png">
+
+
+	<script>var et_site_url='https://hsr.ca.gov';var et_post_id='10928';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}</script><title>Board Meeting Schedule &amp; Materials &#x2d; California High Speed Rail</title>
+<meta name='robots' content='max-image-preview:large'/>
+
+<!-- The SEO Framework by Sybre Waaijer -->
+<meta name="robots" content="max-snippet:-1,max-image-preview:standard,max-video-preview:-1"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:type" content="website"/>
+<meta property="og:title" content="Board Meeting Schedule &amp; Materials &#x2d; California High Speed Rail"/>
+<meta property="og:url" content="https://hsr.ca.gov/about/board-of-directors/schedule/"/>
+<meta property="og:site_name" content="California High Speed Rail"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Board Meeting Schedule &amp; Materials &#x2d; California High Speed Rail"/>
+<link rel="canonical" href="https://hsr.ca.gov/about/board-of-directors/schedule/"/>
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item": {
+                "@id": "https://hsr.ca.gov/",
+                "name": "California High Speed Rail"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/",
+                "name": "About"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/board-of-directors/",
+                "name": "Board of Directors"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 4,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/board-of-directors/schedule/",
+                "name": "Board Meeting Schedule &amp; Materials"
+            }
+        }
+    ]
+}</script>
+<!-- / The SEO Framework by Sybre Waaijer | 11.95ms meta | 2.04ms boot -->
+
+<link rel='dns-prefetch' href='//fonts.googleapis.com'/>
+<link rel='dns-prefetch' href='//s.w.org'/>
+<link rel="alternate" type="application/rss+xml" title="California High Speed Rail &raquo; Feed" href="https://hsr.ca.gov/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="California High Speed Rail &raquo; Comments Feed" href="https://hsr.ca.gov/comments/feed/"/>
+		<script type="text/javascript">window._wpemojiSettings={"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/svg\/","svgExt":".svg","source":{"wpemoji":"https:\/\/hsr.ca.gov\/wp-includes\/js\/wp-emoji.js?ver=5.7.7","twemoji":"https:\/\/hsr.ca.gov\/wp-includes\/js\/twemoji.js?ver=5.7.7"}};(function(window,document,settings){var src,ready,ii,tests;var canvas=document.createElement('canvas');var context=canvas.getContext&&canvas.getContext('2d');function emojiSetsRenderIdentically(set1,set2){var stringFromCharCode=String.fromCharCode;context.clearRect(0,0,canvas.width,canvas.height);context.fillText(stringFromCharCode.apply(this,set1),0,0);var rendered1=canvas.toDataURL();context.clearRect(0,0,canvas.width,canvas.height);context.fillText(stringFromCharCode.apply(this,set2),0,0);var rendered2=canvas.toDataURL();return rendered1===rendered2;}function browserSupportsEmoji(type){var isIdentical;if(!context||!context.fillText){return false;}context.textBaseline='top';context.font='600 32px Arial';switch(type){case'flag':isIdentical=emojiSetsRenderIdentically([0x1F3F3,0xFE0F,0x200D,0x26A7,0xFE0F],[0x1F3F3,0xFE0F,0x200B,0x26A7,0xFE0F]);if(isIdentical){return false;}isIdentical=emojiSetsRenderIdentically([0xD83C,0xDDFA,0xD83C,0xDDF3],[0xD83C,0xDDFA,0x200B,0xD83C,0xDDF3]);if(isIdentical){return false;}isIdentical=emojiSetsRenderIdentically([0xD83C,0xDFF4,0xDB40,0xDC67,0xDB40,0xDC62,0xDB40,0xDC65,0xDB40,0xDC6E,0xDB40,0xDC67,0xDB40,0xDC7F],[0xD83C,0xDFF4,0x200B,0xDB40,0xDC67,0x200B,0xDB40,0xDC62,0x200B,0xDB40,0xDC65,0x200B,0xDB40,0xDC6E,0x200B,0xDB40,0xDC67,0x200B,0xDB40,0xDC7F]);return!isIdentical;case'emoji':isIdentical=emojiSetsRenderIdentically([0xD83D,0xDC68,0x200D,0xD83C,0xDF7C],[0xD83D,0xDC68,0x200B,0xD83C,0xDF7C]);return!isIdentical;}return false;}function addScript(src){var script=document.createElement('script');script.src=src;script.defer=script.type='text/javascript';document.getElementsByTagName('head')[0].appendChild(script);}tests=Array('flag','emoji');settings.supports={everything:true,everythingExceptFlag:true};for(ii=0;ii<tests.length;ii++){settings.supports[tests[ii]]=browserSupportsEmoji(tests[ii]);settings.supports.everything=settings.supports.everything&&settings.supports[tests[ii]];if('flag'!==tests[ii]){settings.supports.everythingExceptFlag=settings.supports.everythingExceptFlag&&settings.supports[tests[ii]];}}settings.supports.everythingExceptFlag=settings.supports.everythingExceptFlag&&!settings.supports.flag;settings.DOMReady=false;settings.readyCallback=function(){settings.DOMReady=true;};if(!settings.supports.everything){ready=function(){settings.readyCallback();};if(document.addEventListener){document.addEventListener('DOMContentLoaded',ready,false);window.addEventListener('load',ready,false);}else{window.attachEvent('onload',ready);document.attachEvent('onreadystatechange',function(){if('complete'===document.readyState){settings.readyCallback();}});}src=settings.source||{};if(src.concatemoji){addScript(src.concatemoji);}else if(src.wpemoji&&src.twemoji){addScript(src.twemoji);addScript(src.wpemoji);}}})(window,document,window._wpemojiSettings);</script>
+		<meta content="CAWeb v.1.5.0" name="generator"/><style type="text/css">img.wp-smiley,img.emoji{display:inline!important;border:none!important;box-shadow:none!important;height:1em!important;width:1em!important;margin:0 .07em!important;vertical-align:-.1em!important;background:none!important;padding:0!important}</style>
+	<link rel='stylesheet' id='dashicons-css' href='https://hsr.ca.gov/wp-includes/css/dashicons.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='thickbox-css' href='https://hsr.ca.gov/wp-includes/js/thickbox/thickbox.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='wp-block-library-css' href='https://hsr.ca.gov/wp-includes/css/dist/block-library/style.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='trp-floater-language-switcher-style-css' href='https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/css/trp-floater-language-switcher.css?ver=2.0.1' type='text/css' media='all'/>
+<link rel='stylesheet' id='trp-language-switcher-style-css' href='https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/css/trp-language-switcher.css?ver=2.0.1' type='text/css' media='all'/>
+<link rel='stylesheet' id='parent-style-css' href='https://hsr.ca.gov/wp-content/themes/Divi/style.dev.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='divi-style-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/style.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='symsoft-divi-extension-styles-css' href='https://hsr.ca.gov/wp-content/plugins/hsr-plugins/styles/style.min.css?ver=1.0.0' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-module-extension-styles-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/divi/extension/styles/style.min.css?ver=1.0.0' type='text/css' media='all'/>
+<link rel='stylesheet' id='et-builder-googlefonts-cached-css' href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200italic,300,300italic,regular,italic,600,600italic,700,700italic,900,900italic&#038;subset=latin,latin-ext&#038;display=swap' type='text/css' media='all'/>
+<link rel='stylesheet' id='tablepress-default-css' href='https://hsr.ca.gov/wp-content/plugins/tablepress/css/default.css?ver=1.13' type='text/css' media='all'/>
+<link rel='stylesheet' id='tablepress-responsive-tables-css' href='https://hsr.ca.gov/wp-content/plugins/tablepress-responsive-tables/css/tablepress-responsive.css?ver=1.8' type='text/css' media='all'/>
+<link rel='stylesheet' id='et-shortcodes-responsive-css-css' href='https://hsr.ca.gov/wp-content/themes/Divi/epanel/shortcodes/css/shortcodes_responsive.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='magnific-popup-css' href='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/styles/magnific_popup.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-core-style-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/css/cagov-v5-oceanside.min.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='cagov-google-font-style-css' href='https://fonts.googleapis.com/css?family=Asap+Condensed%3A400%2C600%7CSource+Sans+Pro%3A400%2C700&#038;ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-custom-css-styles-css' href='https://hsr.ca.gov/wp-content/caweb-1.5.0-ext/css/1/caweb-custom.css?ver=-633cd37e9cb523.24925510' type='text/css' media='all'/>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/jquery/jquery.js?ver=3.5.1' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/jquery/jquery-migrate.js?ver=3.3.2' id='jquery-migrate-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/plugins/wpo365-login/apps/dist/pintra-redirect.js,qver=12.11.pagespeed.ce.LufbUBx-BK.js' id='pintraredirectjs-js'></script>
+<script type='text/javascript' defer src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/js/libs/modernizr-3.6.0.min.js?ver=5.7.7' id='cagov-modernizr-script-js'></script>
+<link rel="https://api.w.org/" href="https://hsr.ca.gov/wp-json/"/><link rel="alternate" type="application/json" href="https://hsr.ca.gov/wp-json/wp/v2/pages/10928"/><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://hsr.ca.gov/xmlrpc.php?rsd"/>
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://hsr.ca.gov/wp-includes/wlwmanifest.xml"/> 
+<link rel="alternate" type="application/json+oembed" href="https://hsr.ca.gov/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fhsr.ca.gov%2Fabout%2Fboard-of-directors%2Fschedule%2F"/>
+<link rel="alternate" type="text/xml+oembed" href="https://hsr.ca.gov/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fhsr.ca.gov%2Fabout%2Fboard-of-directors%2Fschedule%2F&#038;format=xml"/>
+<link rel="alternate" hreflang="en-US" href="https://hsr.ca.gov/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="en" href="https://hsr.ca.gov/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="es-MX" href="https://hsr.ca.gov/es/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="es" href="https://hsr.ca.gov/es/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="ar" href="https://hsr.ca.gov/ar/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="hy" href="https://hsr.ca.gov/hy/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="hmn" href="https://hsr.ca.gov/hmn/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="zh-TW" href="https://hsr.ca.gov/zh/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="zh" href="https://hsr.ca.gov/zh/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="zh-HK" href="https://hsr.ca.gov/zh_hk/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="zh-CN" href="https://hsr.ca.gov/zh_cn/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="ko-KR" href="https://hsr.ca.gov/ko/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="ko" href="https://hsr.ca.gov/ko/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="ja" href="https://hsr.ca.gov/ja/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="pa-IN" href="https://hsr.ca.gov/pa/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="pa" href="https://hsr.ca.gov/pa/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="tl" href="https://hsr.ca.gov/tl/about/board-of-directors/schedule/"/>
+<link rel="alternate" hreflang="vi" href="https://hsr.ca.gov/vi/about/board-of-directors/schedule/"/>
+<script>(function($){$(window).bind("load",function(){$('.fluid-width-video-wrapper').each(function(){var src=$(this).find('iframe').attr('src');$(this).find('iframe').attr('src',src+'&amp;rel=0');});});})(jQuery)</script>
+
+<link title="Fav Icon" rel="icon" href="https://hsr.ca.gov/wp-content/uploads/2020/12/favicon.ico">
+<link rel="shortcut icon" href="https://hsr.ca.gov/wp-content/uploads/2020/12/favicon.ico">
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/><link rel="preload" href="https://hsr.ca.gov/wp-content/themes/Divi/core/admin/fonts/modules.ttf" as="font" crossorigin="anonymous"><link rel="shortcut icon" href=""/><style type="text/css">.broken_link,a.broken_link{text-decoration:line-through}</style><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.4.6/css/swiper.min.css"><link rel="stylesheet" id="et-divi-customizer-global-cached-inline-styles" href="https://hsr.ca.gov/wp-content/et-cache/1/1/global/et-divi-customizer-global-16595570436405.min.css" onerror="et_core_page_resource_fallback(this, true)" onload="et_core_page_resource_fallback(this)"/>
+
+</head>
+<body class="page-template-default page page-id-10928 page-parent page-child parent-pageid-1126 primary translatepress-en_US et_pb_button_helper_class et_header_style_left et_pb_footer_columns4 et_cover_background et_pb_gutter osx et_pb_gutters3 et_pb_pagebuilder_layout et_no_sidebar et_divi_theme et-db divi_builder title_not_displayed v5 sidebar_not_displayed ">
+	<!-- Google Tag Manager (noscript) -->
+<noscript>
+	<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6J3M4W" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+			
+
+<header id="header" class="global-header">
+	<div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+	<!-- Alert Banners -->
+<!-- Utility Header -->
+<div class="utility-header hidden-print">
+	<div class="container">
+		<div class="group flex-row">
+			<div class="social-media-links">
+				<div class="header-cagov-logo">
+					<a href="https://www.ca.gov/" title="CA.gov website">
+						<span class="sr-only">CA.gov</span>
+						<script data-pagespeed-no-defer>//<![CDATA[
+(function(){for(var g="function"==typeof Object.defineProperties?Object.defineProperty:function(b,c,a){if(a.get||a.set)throw new TypeError("ES3 does not support getters and setters.");b!=Array.prototype&&b!=Object.prototype&&(b[c]=a.value)},h="undefined"!=typeof window&&window===this?this:"undefined"!=typeof global&&null!=global?global:this,k=["String","prototype","repeat"],l=0;l<k.length-1;l++){var m=k[l];m in h||(h[m]={});h=h[m]}var n=k[k.length-1],p=h[n],q=p?p:function(b){var c;if(null==this)throw new TypeError("The 'this' value for String.prototype.repeat must not be null or undefined");c=this+"";if(0>b||1342177279<b)throw new RangeError("Invalid count value");b|=0;for(var a="";b;)if(b&1&&(a+=c),b>>>=1)c+=c;return a};q!=p&&null!=q&&g(h,n,{configurable:!0,writable:!0,value:q});var t=this;function u(b,c){var a=b.split("."),d=t;a[0]in d||!d.execScript||d.execScript("var "+a[0]);for(var e;a.length&&(e=a.shift());)a.length||void 0===c?d[e]?d=d[e]:d=d[e]={}:d[e]=c};function v(b){var c=b.length;if(0<c){for(var a=Array(c),d=0;d<c;d++)a[d]=b[d];return a}return[]};function w(b){var c=window;if(c.addEventListener)c.addEventListener("load",b,!1);else if(c.attachEvent)c.attachEvent("onload",b);else{var a=c.onload;c.onload=function(){b.call(this);a&&a.call(this)}}};var x;function y(b,c,a,d,e){this.h=b;this.j=c;this.l=a;this.f=e;this.g={height:window.innerHeight||document.documentElement.clientHeight||document.body.clientHeight,width:window.innerWidth||document.documentElement.clientWidth||document.body.clientWidth};this.i=d;this.b={};this.a=[];this.c={}}function z(b,c){var a,d,e=c.getAttribute("data-pagespeed-url-hash");if(a=e&&!(e in b.c))if(0>=c.offsetWidth&&0>=c.offsetHeight)a=!1;else{d=c.getBoundingClientRect();var f=document.body;a=d.top+("pageYOffset"in window?window.pageYOffset:(document.documentElement||f.parentNode||f).scrollTop);d=d.left+("pageXOffset"in window?window.pageXOffset:(document.documentElement||f.parentNode||f).scrollLeft);f=a.toString()+","+d;b.b.hasOwnProperty(f)?a=!1:(b.b[f]=!0,a=a<=b.g.height&&d<=b.g.width)}a&&(b.a.push(e),b.c[e]=!0)}y.prototype.checkImageForCriticality=function(b){b.getBoundingClientRect&&z(this,b)};u("pagespeed.CriticalImages.checkImageForCriticality",function(b){x.checkImageForCriticality(b)});u("pagespeed.CriticalImages.checkCriticalImages",function(){A(x)});function A(b){b.b={};for(var c=["IMG","INPUT"],a=[],d=0;d<c.length;++d)a=a.concat(v(document.getElementsByTagName(c[d])));if(a.length&&a[0].getBoundingClientRect){for(d=0;c=a[d];++d)z(b,c);a="oh="+b.l;b.f&&(a+="&n="+b.f);if(c=!!b.a.length)for(a+="&ci="+encodeURIComponent(b.a[0]),d=1;d<b.a.length;++d){var e=","+encodeURIComponent(b.a[d]);131072>=a.length+e.length&&(a+=e)}b.i&&(e="&rd="+encodeURIComponent(JSON.stringify(B())),131072>=a.length+e.length&&(a+=e),c=!0);C=a;if(c){d=b.h;b=b.j;var f;if(window.XMLHttpRequest)f=new XMLHttpRequest;else if(window.ActiveXObject)try{f=new ActiveXObject("Msxml2.XMLHTTP")}catch(r){try{f=new ActiveXObject("Microsoft.XMLHTTP")}catch(D){}}f&&(f.open("POST",d+(-1==d.indexOf("?")?"?":"&")+"url="+encodeURIComponent(b)),f.setRequestHeader("Content-Type","application/x-www-form-urlencoded"),f.send(a))}}}function B(){var b={},c;c=document.getElementsByTagName("IMG");if(!c.length)return{};var a=c[0];if(!("naturalWidth"in a&&"naturalHeight"in a))return{};for(var d=0;a=c[d];++d){var e=a.getAttribute("data-pagespeed-url-hash");e&&(!(e in b)&&0<a.width&&0<a.height&&0<a.naturalWidth&&0<a.naturalHeight||e in b&&a.width>=b[e].o&&a.height>=b[e].m)&&(b[e]={rw:a.width,rh:a.height,ow:a.naturalWidth,oh:a.naturalHeight})}return b}var C="";u("pagespeed.CriticalImages.getBeaconData",function(){return C});u("pagespeed.CriticalImages.Run",function(b,c,a,d,e,f){var r=new y(b,c,a,e,f);x=r;d&&w(function(){window.setTimeout(function(){A(r)},0)})});})();pagespeed.CriticalImages.Run('/mod_pagespeed_beacon','https://hsr.ca.gov/about/board-of-directors/schedule/','8Xxa2XQLv9',true,false,'ky5pKuUJCTY');
+//]]></script><img style="height: 31px;" src="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/logo.svg" class="pos-rel" alt="CA.gov website" aria-hidden="true" data-pagespeed-url-hash="3038728008" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/>
+					</a>
+				</div>
+
+									<a href="/" title="Home" class="utility-home-icon ca-gov-icon-home"><span class="sr-only">Home</span></a>
+											<a class="utility-social-facebook ca-gov-icon-facebook" href="https://www.facebook.com/CaliforniaHighSpeedRail/" title="Share via Facebook" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Facebook</span>
+						</a>
+												<a class="utility-social-twitter ca-gov-icon-twitter" href="https://twitter.com/cahsra" title="Share via Twitter" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Twitter</span>
+						</a>
+												<a class="utility-social-flickr ca-gov-icon-flickr" href="https://www.flickr.com/photos/hsrcagov/" title="Share via Flickr" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Flickr</span>
+						</a>
+												<a class="utility-social-youtube ca-gov-icon-youtube" href="https://www.youtube.com/CAHighSpeedRail" title="Share via YouTube" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via YouTube</span>
+						</a>
+												<a class="utility-social-instagram ca-gov-icon-instagram" href="https://www.instagram.com/cahsra/" title="Share via Instagram" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Instagram</span>
+						</a>
+												<a class="utility-social-linkedin ca-gov-icon-linkedin" href="https://www.linkedin.com/company/california-high-speed-rail-authority" title="Share via LinkedIn" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via LinkedIn</span>
+						</a>
+									</div>
+			<div class="settings-links">
+				<a class="utility-custom-1" href="/wp-content/uploads/docs/about/SIMM_25B_Web_Accessibility_Cert.pdf">ADA Certification</a><a class="utility-custom-2" href="/a-to-z-index/">A to Z Index</a>								<a class="utility-contact-us" href="/contact/">Contact Us</a>
+				
+												<button class="btn btn-xs btn-primary collapsed" data-toggle="collapse" data-target="#siteSettings" aria-controls="siteSettings">
+					<span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="site-settings section section-standout collapse collapsed" aria-atomic="true" role="alert" id="siteSettings">
+	<div class="container  p-y">
+		<div class="btn-group btn-group-justified-sm" role="group" aria-label="contrastMode">
+			<div class="btn-group"><button type="button" class="btn btn-standout disableHighContrastMode">Default</button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High Contrast</button></div>
+		</div>
+
+		<div class="btn-group" role="group" aria-label="textSizeMode">
+			<div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <span class="sr-only">Increase</span><span class="ca-gov-icon-plus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <span class="sr-only">Decrease</span><span class="ca-gov-icon-minus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+		</div>
+		<button type="button" class="close" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	</div>
+</div>
+<!-- Branding -->
+<div class="branding">
+	<div class="header-organization-banner">
+		<a href="/">
+			<img src="https://hsr.ca.gov/wp-content/uploads/2021/05/HSR_Logo_80px_height.png" alt="CA High-Speed Rail Authority Logo" data-pagespeed-url-hash="62514589" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/>
+		</a>
+	</div>
+</div>
+<!-- mobile navigation controls -->
+<div class="mobile-controls">
+    <span class="mobile-control-group mobile-header-icons">
+        <!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+    <div class="mobile-control-group main-nav-icons">
+                <button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+                <button id="nav-icon3" class="mobile-control toggle-menu" aria-expanded="false" aria-controls="navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+
+    </div>
+</div>
+
+	<div class="navigation-search">
+
+		<!-- Version 4 top-right search box always displayed -->
+		<!-- Version 5.0 fade in/out search box displays on front page and if option is enabled -->
+		<!-- Include Navigation -->
+		<nav id="navigation" class="main-navigation singlelevel hidden-print">
+                                <ul id="nav_list" class="top-level-nav"><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor  " title=""><a href="https://hsr.ca.gov/about/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">About</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/programs/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Programs</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/high-speed-rail-in-california/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">High-Speed Rail in California</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/business-opportunities/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Business Opportunities</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/jobs/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Jobs</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/communications-outreach/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Communications &amp; Outreach</span></a></li><li class="nav-item" id="nav-item-search"><button class="first-level-link h-auto"><span class="ca-gov-icon-search" aria-hidden="true"></span> Search</button></li></ul></nav>		<div id="head-search" class="search-container hidden-print" role="region" aria-label="Search Expanded">
+			<div class="container">
+	<form id="Search" class="pos-rel" action="https://hsr.ca.gov/serp">
+		<span class="sr-only" id="SearchInput">Custom Google Search</span>
+		<input type="text" id="q" name="q" value="" aria-labelledby="SearchInput" placeholder="Search this website" class="search-textfield height-50 border-0 p-x-sm w-100"/>
+		<button type="submit" class="pos-abs gsc-search-button top-0 width-50 height-50 border-0 bg-transparent">
+			<span class="ca-gov-icon-search font-size-30 color-gray"></span>
+			<span class="sr-only">Submit</span>
+		</button>
+		<div class="width-50 height-50 close-search-btn">
+			<!-- Some Google styles add an 'x' background image when button has 'gsc-clear-button' in the class -->
+			<button class="close-search width-50 height-50 border-0 bg-transparent pos-rel" type="reset">
+				<span class="sr-only">Close Search</span>
+				<span class="ca-gov-icon-close-mark"></span>
+			</button>
+		</div>
+	</form>
+</div>
+		</div>
+	</div>
+</header>
+
+	<div id="page-container">
+		<div id="et-main-area">
+
+			<div id="main-content" class="main-content" tabindex="-1">
+				<main class="main-primary">
+
+					
+					<article id="post-10928" class="post-10928 page type-page status-publish hentry">
+
+						<div class="entry-content"><div id="et-boc" class="et-boc">
+			
+		<div class="et-l et-l--post">
+			<div class="et_builder_inner_content et_pb_gutters3">
+		<div class="et_pb_section et_pb_section_0 et_section_specialty">
+				
+				
+				
+				<div class="et_pb_row">
+					<div class="et_pb_column et_pb_column_2_3 et_pb_column_0   et_pb_specialty_column  et_pb_css_mix_blend_mode_passthrough">
+				
+				
+				<div class="et_pb_row_inner et_pb_row_inner_0">
+				<div class="et_pb_column et_pb_column_4_4 et_pb_column_inner et_pb_column_inner_0 et-last-child">
+				
+				
+				<div class="et_pb_with_border et_pb_module et_pb_ca_breadcrumb et_pb_ca_breadcrumb_0">
+				
+				
+				
+				
+				<div class="et_pb_module_inner">
+					<ol class="breadcrumb"><li><a href="/" title="home">Home</a></li><li><a href="https://hsr.ca.gov/about/" title="About">About</a></li><li><a href="https://hsr.ca.gov/about/board-of-directors/" title="Board of Directors">Board of Directors</a></li><li>Board Meeting Schedule &amp; Materials</li></ol>
+				</div>
+			</div><div class="et_pb_module et_pb_text et_pb_text_0  et_pb_text_align_left et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><h1>Board Meeting Schedule &amp; Materials</h1>
+<p>Meetings of the California High-Speed Rail Authority Board of Directors are held in Sacramento, CA and begin at 10:00 a.m. unless the agenda reflects otherwise. Meeting dates, times and locations are subject to change; check this website before making final plans to attend a specific meeting. Click the following link for agendas and materials for the <a href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/">Finance &amp; Audit Committee Meetings</a>.</p>
+<h2>2022 Board Meeting Schedule</h2>
+<ul>
+<li>Wednesday, January 19, 2022 and Thursday, January 20, 2022</li>
+<li>Tuesday, February 1, 2022</li>
+<li>Thursday, February 17, 2022</li>
+<li>Thursday, March 17, 2022</li>
+<li>Wednesday, April 27, 2022 and Thursday, April 28, 2022</li>
+<li>Thursday, May 19, 2022 (CANCELED)</li>
+<li>Thursday, June 16, 2022</li>
+<li>Thursday, July 21, 2022 (CANCELED)</li>
+<li>Wednesday, August 17, 2022 and Thursday, August 18, 2022 (Virtual)</li>
+<li>Thursday, September 15, 2022</li>
+<li>Thursday, October 20, 2022</li>
+<li>Thursday, November 17, 2022</li>
+<li>Thursday, December 15, 2022</li>
+</ul>
+<p>&nbsp;</p>
+<h2>2022 Board Meeting Materials</h2></div>
+			</div> <!-- .et_pb_text --><div class="et_pb_module et_pb_toggle et_pb_toggle_0 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">September 15, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/09/05/board-of-directors-meeting-4/">September 15, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/ShlVl2Tf6y0">September 15, 2022 Board Meeting Video</a></li>
+</ul>
+<p>Agenda Item #1 Election of Board Chair and Vice Chair</p>
+<p>Agenda Item #2 Consider Approving the August 17-18, 2022, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Agenda-Item-2-August-17-18-2022-Board-Meeting-Minutes-A11Y.pdf">August 17-18, 2022, Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #3 Consider Approving the 2022 Proposition 1A Funding Plan</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/2022-Prop-1A-Funding-Plan-Board-Memo-September-2022-A11Y.pdf">Board Memo: Consider Approving the 2022 Proposition 1A Funding Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/2022-Prop-1A-Funding-Plan-Draft-Board-Resolution-A11Y.pdf">Draft Resolution #HSRA 22-22 Approval of the 2022 Proposition 1A Funding Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/2022-Proposition-1A-Funding-Plan-090722-A11Y.pdf">2022 Proposition 1A Funding Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Prop-1A-Funding-Plan-Independent-Financial-Advisor-Report-FINAL-090722-A11Y.pdf">Independent Finance Advisor Report to California High-Speed Rail Authority Regarding: Proposition 1A Funding Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/2022-Proposition-1A-Funding-Plan-PPT-Presentation-September-2022-A11Y.pdf">PowerPoint: 2022 Proposition 1A Funding Plan</a></li>
+</ul>
+<p>Agenda Item #4 Southern CA Update</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Sept-2022-Board-of-Directors-memo-SoCal-draft-A11Y.pdf">Board Memo: Southern California Update</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Final-Sept-2022-Board-PPT-A11Y.pdf">PowerPoint: Southern CA Update</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Rosecrans-Marquardt-Link-US-Final-CHSRA-Board-Presentation-15Sept2022-A11Y.pdf">PowerPoint: Rosecrans Marquardt Grade Separation &amp; Link Union Station Project Updates</a></li>
+</ul>
+<p>Agenda Item #5 CEO Report</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Sept-2022-Board-of-Directors-Memo-CEO-Report-A11Y.pdf">Board Memo: CEO Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/BK-CEO-Report-Sept-2022-A11Y.pdf">PowerPoint: September CEO Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Caltrain-Letter-080322-A11Y.pdf">Caltrain / High-Speed Rail joint letter </a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_1 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">August 17-18, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Final-Agenda-Amended-A11Y.pdf">August 17-18, 2022 Board Meeting Agenda (Amended)</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Final-Agenda-002-A11Y.pdf">August 17-18, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/kckTAMMwLHs">August 17, 2022 Board Meeting Video (Day 1)</a></li>
+<li><a href="https://youtu.be/fsEZ5Bal4W4">August 18, 2022 Board Meeting Video (Day 2)</a></li>
+</ul>
+<p>Agenda Item #2 Consider Approving the June 16, 2022, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-No2-June-16-2022-Board-Meeting-Minutes-A11Y.pdf">June 16, 2022 Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #3 Staff Presentation on the San Francisco to San Jose Project Section Final EIR/EIS and Proposed Selection of the Portion of the Preferred Alternative (Alternative A with Caltrain Stations modified for HSR at 4th and King Streets and Millbrae, an East Brisbane Light Maintenance Facility, and the Millbrae Station Design) from the 4th and King Station in San Francisco to Scott Boulevard in Santa Clara and Related Decisions</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting_Agenda-Item-3_F-J-Memo-A11y.pdf">Board Memo: Staff Presentation on the San Francisco to San Jose Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/F-J_Day1-Presentation-DraftV0-A11Y.pdf">PowerPoint: Staff Presentation on the San Francisco to San Jose Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-Board-Memo-Attachment-A-Map-A11Y.pdf">Attachment A: Map of the Portion of the Preferred Alternative under Consideration for Approval</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-Board-Memo-Attachment-B-Standard-Responses-A11Y.pdf">Attachment B: Standard Responses to Most Frequently Raised Comments</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Agenda-3_-FJ_Board_Memo_Attachment_C_Summary.pdf">Attachment C: Executive Summary of the San Francisco to San Jose Project Section Final EIR/EIS</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-CEQA-Certification-Resolution-A11Y.pdf">Attachment D: Draft Resolution #HSRA 22-19</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-CEQA-Approval-Resolution-A11Y.pdf">Attachment E: Draft Resolution #HSRA 22-20</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-19_FJ_CEQA_Approval_Resolution_Exhibit_A_Map.pdf">Exhibit A – Map of the Portion of the Preferred Alternative under Consideration for Approval</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_Draft_Findings_SOC.pdf">Exhibit B – Draft CEQA Findings of Fact and Statement of Overriding Considerations</a>
+<ul>
+<li>Attachment A (to Exhibit B) – Draft Mitigation Monitoring and Enforcement Plan</li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-NEPA-Approval-Resolution-A11Y.pdf">Attachment F: Draft Resolution #HSRA 22-21</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_NEPA_Approval_Resolution_Exhibit_A_ROD.pdf">Exhibit A – Draft Record of Decision for the San Francisco to San Jose Project Section</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_A_Final_GCD_Signed.pdf">Appendix A – Final General Conformity Determination</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_B_USFWS_BO.pdf">Appendix B – U.S. Fish and Wildlife Service Biological Opinion</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_C_NMFS_BO.pdf">Appendix C – National Marine Fisheries Service Biological Opinion</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_Draft_ROD_Appendix_D_MMEP.pdf">Appendix D – Draft Mitigation Monitoring and Enforcement Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_E_SHPO-concurrence-and-MOA.pdf">Appendix E – State Historic Preservation Officer Section 106 Concurrence Letter and Memorandum of Agreement</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_F_USACE-EPA_LEDPA-Concurrence.pdf">Appendix F – U.S. Army Corps of Engineers Least Environmentally Damaging Practicable Alternative (LEDPA) Concurrence Letter and U.S. Environmental Protection Agency LEDPA Concurrence Letter</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_Draft_ROD_Appendix_G_Comments.pdf">Appendix G – Comments Received after Publication of the Final EIS</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_H_Errata.pdf">Appendix H – Errata for Final EIS</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p>Agenda Item #4 State Budget Agreement Summary and Consideration of Adopting the 2022/2023 Fiscal Year Budget</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-4-Budget-Memo-A11Y.pdf">Board Memo: 2022-23 Fiscal Year Budget</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-4-Budget-Final-Resolution-22-13-A11Y.pdf">Final Resolution #HSRA 22-13 Consider Accepting the Fiscal Year 2022-23 Budgets</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-4-Budget-Draft-Resolution-22-13-A11Y.pdf">Draft Resolution #HSRA 22-13 Consider Accepting the Fiscal Year 2022-23 Budgets</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Board_Meeting_Request_FY22_23-Budget-and-Baseline_v51-A11Y.pdf">PowerPoint: 2022-23 Fiscal Year Budget Request</a></li>
+</ul>
+<p>(Moved to Future Meeting) Agenda Item #5 Consider Awarding the Contract for Program Delivery Support Services</p>
+<p>Agenda Item #6 Consider Providing Approval to Award the Contract for Design Services for the Merced to Madera Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-6-Design-Services-Board-Memo-2-A11Y.pdf">Board Memo: Consider Providing Approval to Award the Contract for Design Services for the Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-6-Design-Services-Board-final-Resolution-2-A11Y.pdf">Final Resolution #HSRA 22-15 Approval to Award the Contract for Design Services for the Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-6-Design-Services-Board-Draft-Resolution-2-A11Y.pdf">Draft Resolution #HSRA 22-15 Approval to Award the Contract for Design Services for the Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Agenda-Item-6-Design-Services-Board-Presentation-08082022-A11Y.pdf">PowerPoint: Consider Providing Approval to Award the Contract for Design Services for the Merced to Madera Project and Fresno to Bakersfield Locally Generated Alternative (LGA) Project</a></li>
+</ul>
+<p>Agenda Item #7 Consider Providing Approval to Award the Contract for Design Services for the Fresno to Bakersfield Locally Generated Alternative (LGA) Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-7-Design-Services-Board-Memo-A11Y.pdf">Board Memo: Consider Providing Approval to Award the Contract for Design Services for the Fresno to Bakersfield Locally Generated Alternative (LGA) Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-7-Design-Services-Board-final-Resolution-22-16-A11Y.pdf">Final Resolution #HSRA 22-16 Approval to Award the Contract for Design Services for the Fresno to Bakersfield Locally Generated Alternative (LGA) Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-7-Design-Services-Board-Draft-Resolution-22-16-A11Y.pdf">Draft Resolution #HSRA 22-16 Approval to Award the Contract for Design Services for the Fresno to Bakersfield Locally Generated Alternative (LGA) Project</a></li>
+</ul>
+<p>Agenda Item #8 Track and Systems Procurement Stipend Adjustment</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Agenda-Item-8-Track-And-Systems-Stipend-Memo-A11Y.pdf">Board Memo: Track and Systems Procurement Stipend Adjustment</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Item-8-Track-and-System-Stipend-Resolution-Final-Resolution-22-17-A11Y.pdf">Final Resolution #HSRA 22-17 Approval for Track and Systems Procurement Stipend Adjustment</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Item-8-Track-and-System-Stipend-Resolution-Draft-Resolution-22-17-A11Y.pdf">Draft Resolution #HSRA 22-17 Approval for Track and Systems Procurement Stipend Adjustment</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-8-Request-to-Amend-Track-and-Systems-Stipend-Contracts-PPT-A11Y.pdf">PowerPoint: Request to Amend Track and Systems Stipend Contracts</a></li>
+</ul>
+<p>Agenda Item #9 Consider Approving Interagency Agreement with Caltrans for the Wasco SR46 Grade Separation Improvement Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-9-Interagency-Agreement-SR46-Memo-A11Y.pdf">Board Memo: SR46 Grade Separation Improvement Project Interagency Agreement</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/20220808-SR46-IAA-HSR-CT-FINAL-for-approval-A11Y.pdf">Exhibit A &#8211; Scope of Work</a></li>
+</ul>
+</li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-9-Interagency-Agreement-SR46-Final-Resolution-22-18-A11Y.pdf">Final Resolution #HSRA 22-18 Approval to enter Interagency Agreement with Caltrans for the Wasco SR46 Grade Separation Improvement Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-9-Interagency-Agreement-SR46-Draft-Resolution-22-18-A11Y.pdf">Draft Resolution #HSRA 22-18 Approval to enter Interagency Agreement with Caltrans for the Wasco SR46 Grade Separation Improvement Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-2022-Board-Meeting-Agenda-Item-9-Interagency-Agreement-SR46-PPT-A11Y.pdf">PowerPoint: Consider Approving Interagency Agreement with Caltrans for the Wasco SR46 Grade Separation Improvement Project</a></li>
+</ul>
+<p>Agenda Item #10 CEO Report</p>
+<h2>DAY 2- AUGUST 18</h2>
+<p>Agenda Item #11 Finance and Audit Committee Report</p>
+<p>Agenda Item #12 Staff Response to Public Comment Received Following Item #3 Staff Presentation on the San Francisco to San Jose Project Section Final EIR/EIS and Proposed Decisions</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/220817-Assembled-Day-2-Slides-A11Y.pdf">Powerpoint: Staff Response to Public Comment Received Following Item #3 Staff Presentation on the San Francisco to San Jose Project Section Final EIR/EIS and Proposed Decisions</a></li>
+</ul>
+<p>Agenda Item #13 Consider certifying the San Francisco to San Jose Project Section Final EIR/EIS under the California Environmental Quality Act (CEQA)</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-CEQA-Certification-Resolution1-Final-A11Y.pdf">Final Resolution #HSRA 22-19 CEQA Certification of the San Francisco to San Jose Project Section Final Environmental Impact Report/Environmental Impact Statement (EIR/EIS)</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-CEQA-Certification-Resolution-A11Y.pdf">Draft Resolution #HSRA 22-19 CEQA Certification of the San Francisco to San Jose Project Section Final Environmental Impact Report/Environmental Impact Statement (EIR/EIS)</a></li>
+</ul>
+<p>Agenda Item #14 Consider approving the portion of the Preferred Alternative (Alternative A with Caltrain Stations modified for HSR at 4th and King Streets and in Millbrae, an East Brisbane Light Maintenance Facility, the Millbrae Station Design, and associated facilities) from 4th and King Streets in San Francisco to Scott Boulevard in Santa Clara, and the related CEQA Findings of Fact, Statement of Overriding Considerations, and Mitigation Monitoring and Enforcement Plan for the San Francisco to San Jose Project Section</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-CEQA-Approval-Resolution-final-A11Y.pdf">Final Resolution #HSRA 22-20 Approve the Preferred Alternative (Alternative A with Caltrain Stations modified for HSR at 4th and King Streets and in Millbrae, an East Brisbane Light Maintenance Facility, the Millbrae Station Design, and associated facilities) from 4th and King Streets in San Francisco to Scott Boulevard in Santa Clara and Related CEQA Decision Materials</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-CEQA-Approval-Resolution-A11Y.pdf">Draft Resolution #HSRA 22-20 Approve the Preferred Alternative (Alternative A with Caltrain Stations modified for HSR at 4th and King Streets and in Millbrae, an East Brisbane Light Maintenance Facility, the Millbrae Station Design, and associated facilities) from 4th and King Streets in San Francisco to Scott Boulevard in Santa Clara and Related CEQA Decision Materials</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-19_FJ_CEQA_Approval_Resolution_Exhibit_A_Map.pdf">Exhibit A – Map of the Portion of the Preferred Alternative under Consideration for Approval</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_Draft_Findings_SOC.pdf">Exhibit B – Draft CEQA Findings of Fact and Statement of Overriding Considerations</a>
+<ul>
+<li>Attachment A (to Exhibit B) – Draft Mitigation Monitoring and Enforcement Plan</li>
+</ul>
+</li>
+</ul>
+<p>Agenda Item #15 – Consider selecting the portion of the Preferred Alternative (as defined in Item 14) and Directing the Chief Executive Officer to sign a Draft Record of Decision under the National Environmental Policy Act (NEPA) consistent with this selection and to issue a Final Record of Decision for the San Francisco to San Jose Project Section</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/August-17-18-Board-Meeting-Agenda-Item-14-FJ-CEQA-Certification-Resolution-22-21-Final-A11Y-.pdf">Final Resolution #HSRA 22-21 Direct Authority CEO to Issue the Record of Decision for the San Francisco to San Jose Project Section Selecting the Portion of the Preferred Alternative (Alternative A, with Caltrain stations modified for HSR at 4th and King Street and Millbrae, an East Brisbane light maintenance facility, the Millbrae Station Design, and associated facilities) from 4th and King Station in San Francisco to Scott Boulevard in Santa Clara pursuant to NEPA and other Federal Laws</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ-NEPA-Approval-Resolution-A11Y.pdf">Draft Resolution #HSRA 22-21 Direct Authority CEO to Issue the Record of Decision for the San Francisco to San Jose Project Section Selecting the Portion of the Preferred Alternative (Alternative A, with Caltrain stations modified for HSR at 4th and King Street and Millbrae, an East Brisbane light maintenance facility, the Millbrae Station Design, and associated facilities) from 4th and King Station in San Francisco to Scott Boulevard in Santa Clara pursuant to NEPA and other Federal Laws </a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_NEPA_Approval_Resolution_Exhibit_A_ROD.pdf">Exhibit A – Draft Record of Decision for the San Francisco to San Jose Project Section</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_A_Final_GCD_Signed.pdf">Appendix A – Final General Conformity Determination</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_B_USFWS_BO.pdf">Appendix B – U.S. Fish and Wildlife Service Biological Opinion</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_C_NMFS_BO.pdf">Appendix C – National Marine Fisheries Service Biological Opinion</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_Draft_ROD_Appendix_D_MMEP.pdf">Appendix D – Draft Mitigation Monitoring and Enforcement Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_E_SHPO-concurrence-and-MOA.pdf">Appendix E – State Historic Preservation Officer Section 106 Concurrence Letter and Memorandum of Agreement</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_F_USACE-EPA_LEDPA-Concurrence.pdf">Appendix F – U.S. Army Corps of Engineers Least Environmentally Damaging Practicable Alternative (LEDPA) Concurrence Letter and U.S. Environmental Protection Agency LEDPA Concurrence Letter</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/FJ_Draft_ROD_Appendix_G_Comments.pdf">Appendix G – Comments Received after Publication of the Final EIS</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/22-21_FJ_Draft_ROD_Appendix_H_Errata.pdf">Appendix H – Errata for Final EIS</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_2 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">June 16, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/05/01/board-of-directors-meeting-061622/">June 16, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/pLGOpI034Zk">June 16, 2022 Board Meeting Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the April 27-28, 2022, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/2022-April-Board-Meeting-Minutes-A11Y.pdf">April 27-28, 2022 Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 Construction Update</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/2022-June-Board-Memo-Program-Update-BK-A11Y.pdf">Board Memo: Construction Update</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/BK-Construction-Update-June-2022-Board-Meeting-06-14-22-FINAL.pdf">PowerPoint: Construction Update</a></li>
+</ul>
+<p>Agenda Item #3 Federal Grant Strategy</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Board-Memo-Federal-Grant-Strategy-June-2022-A11Y.pdf">Board Memo: Federal Grant Strategy</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Federal-Grant-Strategy-Update-to-Board-FINAL-20220606-A11Y.pdf">PowerPoint: Federal Grant Strategy</a></li>
+</ul>
+<p>Agenda Item #4 CEO Report</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/CEO-Report-June-2022-A11Y.pdf">PowerPoint: June 2022 CEO Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_3 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">May 19, 2022 Board Meeting (CANCELED)</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/05/09/board-of-directors-meeting/">May 19, 2022 Board Meeting Agenda (CANCELED)</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_4 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">April 27-28, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/04/15/board-of-directors-meeting/">April 27-28, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/doZIq2Kbcqs">April 27-28, 2022 Board Meeting Video</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/CHSRA-20220427-Board-Meeting-FINAL-A11Y.pdf">April 27, 2022 Board Meeting Transcript</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/CHSRA-20220428-Board-Meeting-FINAL-A11Y.pdf">April 28, 2022 Board Meeting Transcript</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the March 17, 2022, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/April-27-28-2022-Board-Meeting_Agenda-Item-1_-Board-MEeting-Minutes-.pdf">March 17, 2022 Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 Staff Presentation on the San Jose to Merced Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative (Alternative 4 with a San Jose Diridon Station, Gilroy Station, and South Gilroy Maintenance-of-Way Facility) and Related Decisions</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM-Board-Briefing-Memo-Version-2-FINAL_cd-A11Y.pdf">Board Memo: Staff Presentation on the San Jose to Merced Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/SJ-M_Day1_Presentation_A11Y.pdf">PowerPoint: Staff Presentation on the San Jose to Merced Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Board_Memo_Attachment_A_Map.pdf">Attachment A: Map of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Board_Memo_Attachment_B_Standard_Responses.pdf">Attachment B: Standard Responses to the Most Frequently Raised Comments</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Board_Memo_Attachment_C_Summary.pdf">Attachment C: Executive Summary of the San Jose to Merced Project Section Final EIR/EIS</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM-CEQA-Certification-Resolution-VFM-A11Y.pdf">Attachment D: Draft Resolution #HSRA 22-10</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM-CEQA-Approval-Resolution-22-11-VFM-A11Y.pdf">Attachment E: Draft Resolution #HSRA 22-11</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_CEQA_Approval_Resolution_Exhibit_A_Map.pdf">Exhibit A – Map of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_CEQA_Approval_Resolution_Exhibit_B_FF-SOC.pdf">Exhibit B – Draft CEQA Findings of Fact and Statement of Overriding Considerations</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_CEQA_Approval_Resolution_Exhibit_C_MMEP.pdf">Exhibit C – Draft Mitigation and Monitoring Enforcement Plan</a></li>
+</ul>
+</li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM-NEPA-Approval-Resolution-VFM.pdf">Attachment F: Draft Resolution #HSRA 22-12</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_NEPA_Approval_Resolution_Exhibit_A_ROD.pdf">Exhibit A – Draft Record of Decision for the San Jose to Merced Project Section</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_A_Final_GCD.pdf">Appendix A – General Conformity Determination Memorandum, March 25, 2022</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_B_USFWS_BO.pdf">Appendix B – U.S. Fish and Wildlife Service Biological Opinion, December 22, 2021</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_C_MMEP.pdf">Appendix C – Mitigation Monitoring and Enforcement Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_D_SHPO-concurrence-and-MOA.pdf">Appendix D – State Historic Preservation Officer Section 106 Concurrence Letter and Memorandum of Agreement, March 11, 2022</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_E_NMFS_BO.pdf">Appendix E – National Marine Fisheries Services Biological Opinion, June 24, 2021</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_F_USACE-EPA_LEDPA-Concurrence.pdf">Appendix F – U.S. Army Corps of Engineers Least Environmentally Damaging Practicable Alternative (LEDPA) Concurrence Letter, March 20, 2020, and U.S. Environmental Protection Agency LEDPA Concurrence Letter, March 18, 2020</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_G_Section-4f-Concurrence.pdf">Appendix G – Section 4(f) Concurrence Letters</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_H_Comments.pdf">Appendix H – Comments Received Between the Publication of the Final EIS and the April 27, 2022, Board Meeting</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_I_Errata.pdf">Appendix I – Errata for Final EIS</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/JM_Draft_ROD_Appendix_J_4f.pdf">Appendix J – Final Individual Section 4(f) Evaluation of Two Parks in Santa Clara County</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p>Agenda Item #3 Consider Approving the Project Management and Funding Agreement for Los Angeles Union Station</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/20220427-Agenda-Item-No3-LAUS-PMFA-Board-Memo_A11Y.pdf">Board Memo: Consider Approving the Project Management and Funding Agreement for Los Angeles Union Station</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Final-Resolution-HSR-22-07-Link-US-Funding-Agreement-A11Y.pdf">Final Resolution #HSRA 22-07 Approval of the Project Management and Funding Agreement for the Los Angeles Union Station (Link US) Project, a major capital investment for High-Speed Rail</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/20220427-Board-Meeting-Agenda-Item-No3-Draft-Board-Resolution-PMFA-A11Y.pdf">Draft Resolution #HSRA 22-07 Approval of the Project Management and Funding Agreement for the Los Angeles Union Station (Link US) Project, a major capital investment for High-Speed Rail</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/20220427-Board-Meeting-Agenda-Item-No3-Link-US-Project-PMFA-Presentation-A11Y.pdf">PowerPoint: Consider Approving the Project Management and Funding Agreement for Los Angeles Union Station</a></li>
+</ul>
+<p>Agenda Item #4 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Central Valley Stations</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/20220427-Agenda-Item-No4-Board-Memo-Station-Design-Services-A11Y.pdf">Board Memo: Consider Providing Approval to Release a Request for Qualifications for Design Services for the Central Valley Stations</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/RFQ-Station-Resolution-0224-LC-comment-Draft-2022014-A11Y.pdf">Draft Resolution #HSRA 22-08 Approval to Release a Request for Qualifications for Design Services for Central Valley Stations</a></li>
+<li><a href="http://www.caleprocure.ca.gov/event/2665/0000023121">RFQ: Design Services for the Central Valley Stations</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/20220427-Agenda-Item-No-04-Design-Services-Central-Valley-Stations-Presentation-A11Y.pdf">PowerPoint: Consider Providing Approval to Release a Request for Qualifications for Design Services for the Central Valley Stations</a></li>
+</ul>
+<p>Agenda Item #5 Consider Adopting the 2022 Business Plan<strong> </strong></p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-Board-Memo-Final-BP-A11Y.pdf">Board Memo: Approval of the Final 2022 Business Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-Resolution-Business-Plan-A11Y.pdf">Draft Resolution #HSRA 22-09 Approval of the Final 2022 Business Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Final-Resolution-HSR-22-09-Business-Plan-A11Y.pdf">Final Resolution #HSRA 22-09 Approval of the Final 2022 Business Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022_Revised_Draft_Business_Plan_042022.pdf">Revised Draft 2022 Business Plan</a></li>
+<li><a style="background-color: #ffffff" href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-Business-Plan-Revised-v03-Draft-PPT-Presentation-A11Y.pdf">PowerPoint: Revised Draft 2022 Business Plan</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-Business-Plan-Errata_A11Y.pdf">Revised Draft 2022 Business Plan Errata and Updates Table</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-Business-Plan-Staff-Recommended-Edits_A11Y.pdf">Revised Draft 2022 Business Plan Staff Recommended Edits Table</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-Business-Plan-Staff-Recommended-Edits-SJM.pdf">Revised Draft 2022 Business Plan Staff Recommended Edits, San Jose to Merced Table</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/2022-BP-Public-Comment-Memo-Linked-A11Y.pdf">Public Comments on Revised Draft 2022 Business Plan Memo</a></li>
+</ul>
+<p>Agenda Item #6 CEO Report</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/CEO-Report-April-2022-A11Y.pdf">PowerPoint: CEO Report</a></li>
+</ul>
+<p>Agenda Item #7 Finance and Audit Committee Report</p>
+<p>Agenda Item #8 Staff Response to Public Comment Received Following Item #2 Staff Presentation on the San Jose to Merced Project Section Final EIR/EIS and Proposed Decisions</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/SJ-M-Day2-Presentation-A11Y.pdf">PowerPoint: Staff Response to Public Comment Received Following Item #2 Staff Presentation on the San Jose to Merced Project Section Final EIR/EIS and Proposed Decisions</a></li>
+</ul>
+<p>Agenda Item #9 Consider certifying the San Jose to Merced Project Section Final EIR/EIS under the California Environmental Quality Act</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/JM-CEQA-Certification-Resolution-Final-6.7.pdf">Final Resolution #HSRA 22-10 CEQA Certification of the San Jose to Merced Project Section Final Environmental Impact Report/Environmental Impact Statement</a></li>
+<li>Draft Resolution #HSRA 22-10 CEQA Certification of the San Jose to Merced Project Section Final Environmental Impact Report/Environmental Impact Statement (EIR/EIS)</li>
+</ul>
+<p>Agenda Item #10 Consider Approving the Preferred Alternative (Alternative 4 with a San Jose Diridon Station, Gilroy Station, and South Gilroy Maintenance-of-Way Facility) including associated facilities and refinements, and the related California Environmental Quality Act Findings of Fact, Statement of Overriding Considerations, and Mitigation Monitoring and Enforcement Plan for the San Jose to Merced Project Section</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/JM-CEQA-Approval-Resolution-22-11-Final-6.7.pdf">Final Resolution #HSRA 22-11 Approval of the Preferred Alternative (Alternative 4, with a San Jose Diridon Station, downtown Gilroy Station, and South Gilroy Maintenance-of-Way Facility)</a></li>
+<li>Draft Resolution #HSRA 22-11 Approve the Preferred Alternative (Alternative 4, with a San Jose Diridon Station, downtown Gilroy Station, and South Gilroy Maintenance-of-Way Facility) and Related CEQA Decision Materials
+<ul>
+<li>Exhibit A – Map of the Preferred Alternative</li>
+<li>Exhibit B – Draft CEQA Findings of Fact and Statement of Overriding Considerations</li>
+<li>Exhibit C – Draft Mitigation and Monitoring Enforcement Plan</li>
+</ul>
+</li>
+</ul>
+<p>Agenda Item #11 Consider selecting the Preferred Alternative (as defined in Item 10) and Directing the Chief Executive Officer to sign the Draft Record of Decision and to issue it as a Final Record of Decision for the San Jose to Merced Project Section</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/JM-NEPA-Approval-Resolution-Final-6.7.pdf">Final Resolution #HSRA 22-12 Direct Authority Chief Executive Officer to Issue the Record of Decision for the San Jose to Merced Project Section Selecting Alternative 4 with a San Jose Diridon Station, Downtown Gilroy Station, a South Gilroy Maintenance-of-Way Facility, and associated facilities and refinements, and Complying with Other Federal Laws</a></li>
+<li>Draft Resolution #HSRA 22-12 Direct Authority CEO to Issue the Record of Decision for the San Jose to Merced Project Section Selecting Alternative 4 with a San Jose Diridon Station, Downtown Gilroy Station, a South Gilroy Maintenance-of-Way Facility, and associated facilities and refinements, and Complying with Other Federal Laws
+<ul>
+<li>Exhibit A – Draft Record of Decision for the San Jose to Merced Project Section
+<ul>
+<li>Appendix A – General Conformity Determination Memorandum, March 25, 2022</li>
+<li>Appendix B – U.S. Fish and Wildlife Service Biological Opinion, December 22, 2021</li>
+<li>Appendix C – Mitigation Monitoring and Enforcement Plan</li>
+<li>Appendix D – State Historic Preservation Officer Section 106 Concurrence Letter and Memorandum of Agreement, March 11, 2022</li>
+<li>Appendix E – National Marine Fisheries Services Biological Opinion, June 24, 2021</li>
+<li>Appendix F – U.S. Army Corps of Engineers Least Environmentally Damaging Practicable Alternative (LEDPA) Concurrence Letter, March 20, 2020, and U.S. Environmental Protection Agency LEDPA Concurrence Letter, March 18, 2020</li>
+<li>Appendix G – Section 4(f) Concurrence Letters</li>
+<li>Appendix H – Comments Received Between the Publication of the Final EIS and the April 27, 2022, Board Meeting</li>
+<li>Appendix I – Errata for Final EIS</li>
+<li>Appendix J – Final Individual Section 4(f) Evaluation of Two Parks in Santa Clara County</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_5 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 17, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/03/07/board-of-directors-031722/">March 17, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/LJQe-BSIzBk">March 17, 2022 Board Meeting Video</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/20220317-CHSRA-Board-Meeting-FINAL-TRANSCRIPT-A11Y.pdf">March 17, 2022 Board Meeting Transcript</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the February 17, 2022, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda-Item-1-Board_Meeting_Minutes-Feb-17-2022.pdf">February 17, 2022 Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 Status of the Draft 2022 Business Plan</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda-Item-2-Board-Memo-2022_Draft_BP_A11Y.pdf">Board Memo: Draft 2022 Business Plan Update</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda-Item-2-Draft_BP_PPT_A11Y.pdf">PowerPoint: Draft 2022 Business Plan Update</a></li>
+</ul>
+<p>Agenda Item #3 Northern California Regional Update</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda_Item_3_Board_Memo_NorCal_Update_A11Y.pdf">Board Memo: Northern California Regional Update</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda-Item-3-NorCal_Update_March_Informational_Board_Briefing_Presentation_A11Y.pdf">PowerPoint: Northern California Regional Update</a></li>
+</ul>
+<p>Agenda Item #4 CEO Report</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda_Item4_March_2022_CEO_A11Y.pdf">PowerPoint: CEO Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_6 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">February 17, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/02/07/board-of-directors-meeting-021722/">February 17, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/NHb3PddmXOs">February 17, 2022 Board Meeting Video</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/HSRA_Board_Meeting_Transcript_02-17-22_A11Y.pdf">February 17, 2022 Board Meeting Transcript</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the February 1, 2022 Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Feburary_1_2022_Board_Meeting_Minutes_A11Y.pdf">February 1, 2022 Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 Economic Impact Analysis</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Board_Meeting_Memo_Economic_Impact_Analysis_Item_2_Memo-A11Y.pdf">Board Memo: Economic Impact Analysis</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/2021_Economic_Impact_Analysis-Technical_Supporting_Document.pdf">Technical Supporting Document: 2021 Economic Impact Analysis</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/2021_Economic_Impact_Report_Presentation-FINAL-A11Y.pdf">PowerPoint: Economic Impact Analysis</a></li>
+</ul>
+<p>Agenda Item #3 Consider Providing Approval to Release a Request for Qualifications for Program Delivery Support Services</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Board-Memo_PDS_RFQ_A11Y.pdf">Board Memo: Consider Providing Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/BrdMtg-021722_-Agenda_Item-3_Final_Resolution_PDS_RFQ.pdf">Final Resolution #HSRA 22-04 Consider Providing Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Draft_Resolution_HSRA_22-04_PDS_RFQ_A11Y.pdf">Draft Resolution #HSRA 22-04 Consider Providing Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+<li><a href="https://caleprocure.ca.gov/event/2665/0000021739">RFQ: Program Delivery Support Services</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/PowerPoint_PDS_RFQ_A11Y.pdf">PowerPoint: Consider Providing Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+</ul>
+<p>Agenda Item #4 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Merced to Madera Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Board_Memo_Merced_to_Madera_RFQ_A11Y.pdf">Board Memo: Consider Providing Approval to Release a Request for Qualifications for Design Services for the Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Agenda_Item_4_Final_Resolution_M2M_RFQ_FINAL_A11Y.pdf">Final Resolution #HSRA 22-05 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Draft_Resolution_HSRA_22-05_M2M_RFQ_A11Y.pdf">Draft Resolution #HSRA 22-05 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Merced to Madera Project</a></li>
+<li><a href="https://caleprocure.ca.gov/event/2665/0000021862">RFQ: Design Services for Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Board_Presentation_M2M-_LGA_FINAL_02712022_A11Y.pdf">PowerPoint: Consider Providing Approval to Release a Request for Qualifications for Design Services for the Merced to Madera Project</a></li>
+</ul>
+<p>Agenda Item #5 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Fresno to Bakersfield Locally Generated Alternative Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Board_Memo_LGA_RFQ_A11Y.pdf">Board Memo: Consider Providing Approval to Release a Request for Qualifications for Design Services for the Fresno to Bakersfield Locally Generated Alternative Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Boardmtg_021722_Agenda_Item5_Final_Resolution_-LGA_RFQ_A11Y.pdf">Final Resolution #HSRA 22-06 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Fresno to Bakersfield Locally Generated Alternative Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Draft_Resolution_HSRA_22-06_LGA_RFQ_A11Y.pdf">Draft Resolution #HSRA 22-06 Consider Providing Approval to Release a Request for Qualifications for Design Services for the Fresno to Bakersfield Locally Generated Alternative Project</a></li>
+<li><a href="https://caleprocure.ca.gov/event/2665/0000021861">RFQ: Design Services for the Fresno to Bakersfield Locally Generated Alternative Project</a></li>
+</ul>
+<p>Agenda Item #6 2022 Draft Business Plan Summary</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Board_Memo_Draft_2022_A11Y.pdf">Board Memo: 2022 Draft Business Plan Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/PowerPoint_Draft_2022_BP_A11Y.pdf">PowerPoint: 2022 Draft Business Plan Summary</a></li>
+</ul>
+<p>Agenda Item #7 CEO Report</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/February_2022_CEO_Report__A11Y.pdf">PowerPoint: February CEO Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_7 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">February 1, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/01/21/board-of-directors-meeting-agenda_02012022/">February 1, 2022 Board Meeting Agenda</a></li>
+<li><a href="https://youtu.be/jCcFLB8gcs0">February 1, 2022 Board Meeting Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the January 19-20, 2022, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/January_19-20_2022_Board_Meeting_Minutes_A11Y.pdf">January 19-20, 2022 Board Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 Explanation of the Authority’s Organizational Conflict of Interest Policy</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Board_Memo_OCOI_February_1_2022_Meeting_A11Y.pdf">Board Memo: Explanation of the Authority’s Organizational Conflict of Interest Policy</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/CAHSRA_Organizational_Conflict_of_Interest_Policy_FINAL_013122_A11Y.pdf">PowerPoint: Explanation of the Authority’s Organizational Conflict of Interest Policy</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Organizational_Conflict_Interest_Policy_A11Y.pdf">California High-Speed Rail Authority Organizational Conflict of Interest Policy</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_8 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">January 19-20, 2022 Board Meeting</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/January-19-20-2022-Amended-Agenda.pdf">January 19-20, 2022 Board Meeting Agenda (AMENDED)</a></li>
+<li><a href="https://youtu.be/VtP6arQcBk4">January 19, 2022 Board Meeting Video (Day 1)</a></li>
+<li><a href="https://youtu.be/l8XQhR_wo4I">January 20, 2022 Board Meeting Video (Day 2)</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the December 16, 2021, Board Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/December-16-2021-Board-Meeting-Minutes_A11Y.pdf">December 16, 2021, Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 Staff Presentation on the Burbank to Los Angeles Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative (HSR Build Alternative with an underground Burbank Airport Station, a modified Los Angeles Union Station and two new electrified tracks) and Related Decisions</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Board_Memo_Burbank_Los_Angeles_Final_EIR-EIS_A11Y.pdf">Board Memo: Staff Presentation on the Burbank to Los Angeles Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/220112_B-LA_Board_Meeting_Presentation_FINAL.pdf">PowerPoint: Staff Presentation on the Burbank to Los Angeles Project Section Final EIR/EIS and Proposed Selection of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_E-Exhibit_A-Map_A11Y.pdf">Attachment A: Map of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_B-Summary_A11Y.pdf">Attachment B: Executive Summary of the Burbank to Los Angeles Project Section Final EIR/EIS</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_C-Standard_Responses_A11Y.pdf">Attachment C: Printed Copy of Standard Responses to the Most Frequently Raised Comments</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_D-HSRA-22-01_A11Y.pdf">Attachment D: Draft Resolution #HSRA 22-01</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_E-HSRA_22-02_A11Y.pdf">Attachment E: Draft Resolution #HSRA 22-02</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_E-Exhibit_A-Map_A11Y.pdf">Exhibit A: Map of the Preferred Alternative</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_E-Exhibit_B-FSOC_A11Y.pdf">Exhibit B: Draft CEQA Findings of Fact</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_E-Exhibit_C-MMEP_A11Y.pdf">Exhibit C: Draft Mitigation Monitoring and Enforcement Plan</a></li>
+</ul>
+</li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_F-HSRA-22-03_A11Y.pdf">Attachment F: Draft Resolution #HSRA 22-03</a>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Attachment_F_Exhibit_A-ROD_A11Y.pdf">Exhibit A: Draft Record of Decision for the Burbank to Los Angeles Project Section</a></li>
+</ul>
+</li>
+</ul>
+<p>Agenda Item #3 Consider Providing Approval to Release a Request for Qualifications for Program Delivery Support Services</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Board-Memo_PDS_RFQ_A11Y.pdf">Board Memo: Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Draft_Resolution_HSRA_22-04_PDS_RFQ_A11Y.pdf">Draft Resolution #HSRA 22-04 Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+<li><a href="https://caleprocure.ca.gov/event/2665/0000021739">RFQ: Program Delivery Support Services</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/PPT_PDS_Board_Presentation_A11Y.pdf">PowerPoint: Approval to Release a Request for Qualifications for Program Delivery Support Services</a></li>
+</ul>
+<p>Agenda Item #4 Consider Providing Approval to Release a Request for Qualifications for Design for the Merced to Madera Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Board_Memo_Merced_to_Madera_RFQ_A11Y.pdf">Board Memo: Approval to Release a Request for Qualifications for Design for the Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Draft_Resolution_HSRA_22-05_M2M_RFQ_A11Y.pdf">Draft Resolution #HSRA 22-05 Approval to Release a Request for Qualifications for Design for the Merced to Madera Project</a></li>
+<li><a href="https://caleprocure.ca.gov/event/2665/0000021862">RFQ: Design Services for Merced to Madera Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/PowerPoint_M2M_LGA_FINAL_A11Y.pdf">PowerPoint: Approval to Release a Request for Qualifications for Design for the Merced to Madera Project, and Design for the Fresno to Bakersfield (LGA) Project</a></li>
+</ul>
+<p>Agenda Item #5 Consider Providing Approval to Release a Request for Qualifications for Design for the Fresno to Bakersfield Locally Generated Alternative Project</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Board_Memo_LGA_RFQ_A11Y.pdf">Board Memo: Approval to Release a Request for Qualifications for Design for the Fresno to Bakersfield (LGA) Project</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Draft_Resolution_HSRA_22-06_LGA_RFQ_A11Y.pdf">Draft Resolution #HSRA 22-06 Approval to Release a Request for Qualifications for Design for the Fresno to Bakersfield Locally Generated Alternative Project</a></li>
+<li><a href="https://caleprocure.ca.gov/event/2665/0000021861">RFQ: Design Services for the Fresno to Bakersfield Locally Generated Alternative Project</a></li>
+</ul>
+<p>Agenda Item #6 CEO Report</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/January_2022_CEO_Report_final_A11Y.pdf">PowerPoint: CEO Report</a></li>
+</ul>
+<p>Agenda Item #7 Finance and Audit Committee Report</p>
+<h2>January 20, 2022</h2>
+<p>Agenda Item #8 Staff Response to Public Comment Received Following Item #2 Staff Presentation on the Burbank to Los Angeles Project Section Final EIR/EIS and Proposed Decisions</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Agenda-Item-8-B-LA_Staff_Responses_A11Y.pdf">PowerPoint: Staff Response to Public Comment Received Following Item #2 Staff Presentation on the Burbank to Los Angeles Project Section Final EIR/EIS and Proposed Decisions</a></li>
+</ul>
+<p>Agenda Item #9 Consider Certifying the Burbank to Los Angeles Section Final EIR/EIS under the California Environmental Quality Act (CEQA)</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Final-Resolution-HSRA-22-01_A11Y.pdf">Final Resolution #HSRA 22-01 CEQA Certification of the Burbank to Los Angeles Section Final Environmental Impact Report/Environmental Impact Statement (EIR/EIS)</a></li>
+<li>Draft Resolution #HSRA 22-01 CEQA Certification of the Burbank to Los Angeles Section Final Environmental Impact Report/Environmental Impact Statement (EIR/EIS)</li>
+</ul>
+<p>Agenda Item #10 Consider Approving the Preferred Alternative (the HSR Build Alternative with the underground Burbank Airport Station, a modified Los Angeles Union Station, and two new electrified tracks) including associated facilities, and the related California Environmental Quality Act Findings of Fact, Statement of Overriding Considerations, and Mitigation Monitoring and Enforcement Plan for the Burbank to Los Angeles Project Section</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Final-Resolution-HSRA-22-02_A11Y.pdf">Final Resolution #HSRA 22-02 Approve the Preferred Alternative and Related CEQA Decision Materials</a></li>
+<li>Draft Resolution #HSRA 22-02 Approve the Preferred Alternative and Related CEQA Decision Materials</li>
+<li>Exhibit A – Map of Preferred Alternative</li>
+<li>Exhibit B – Draft CEQA Findings of Fact and Statement of Overriding Considerations</li>
+<li>Exhibit C – Draft Mitigation and Monitoring and Enforcement Plan (MMEP)</li>
+</ul>
+<p>Agenda Item #11 Consider Selecting the Preferred Alternative (as defined in Item #10) and Directing the Chief Executive Officer to sign and issue the Final Record of Decision for the Burbank to Los Angeles Project Section</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Final_Resolution_HSRA_22-03_A11Y.pdf">Final Resolution #HSRA 22-03 Direct Authority CEO to Issue the Record of Decision for the Burbank to Los Angeles Project Section Selecting the HSR Build Alternative and Complying with Other Federal Laws</a></li>
+<li>Draft Resolution #HSRA 22-03 Direct Authority CEO to Issue the Record of Decision for the Burbank to Los Angeles Project Section Selecting the HSR Build Alternative and Complying with Other Federal Laws
+<ul>
+<li>Exhibit A – Draft Record of Decision for the Burbank to Los Angeles Project Section</li>
+</ul>
+</li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle -->
+			</div> <!-- .et_pb_column -->
+				
+				
+			</div> <!-- .et_pb_row_inner -->
+			</div> <!-- .et_pb_column --><div class="et_pb_column et_pb_column_1_3 et_pb_column_1    et_pb_css_mix_blend_mode_passthrough">
+				
+				
+				<div class="et_pb_module et_pb_divider et_pb_divider_0 et_pb_divider_position_ et_pb_space"><div class="et_pb_divider_internal"></div></div><div class="et_pb_module et_pb_ca_siblingPages et_pb_ca_siblingPages_0">
+				
+				
+				
+				
+				<div class="et_pb_module_inner">
+					<ul><li class="page_item page-item-26550"><a href="https://hsr.ca.gov/about/board-of-directors/schedule/2021-minutes/">2021 Board Meeting Schedule &amp; Materials</a><li class="page_item page-item-11596"><a href="https://hsr.ca.gov/about/board-of-directors/schedule/2020-minutes/">2020 Board Meeting Schedule &amp; Materials</a><li class="page_item page-item-11546"><a href="https://hsr.ca.gov/about/board-of-directors/schedule/2019-minutes/">2019 Board Meeting Schedule &#038; Materials</a><li class="page_item page-item-11581"><a href="https://hsr.ca.gov/about/board-of-directors/schedule/2018-minutes/">2018 Board Meeting Schedule &#038; Materials</a></ul>
+				</div>
+			</div><div class="et_pb_module et_pb_image et_pb_image_0">
+				
+				
+				<span class="et_pb_image_wrap "><img loading="lazy" src="https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb.jpg" alt="Board of directors" title="bod-thumb" height="auto" width="auto" srcset="https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb.jpg 278w, https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb-16x8.jpg 16w" sizes="(max-width: 278px) 100vw, 278px" class="wp-image-1484" data-pagespeed-url-hash="1929351878" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/></span>
+			</div><div class="et_pb_module et_pb_code et_pb_code_0">
+				
+				
+				<div class="et_pb_code_inner"><div class="dropdown">
+    <button class="btn btn-primary dropdown-toggle btn-block" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+        Board Meeting Materials
+    </button>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/">2022</a>
+			  <a class="dropdown-item" href="/about/board-of-directors/schedule/2021-minutes">2021</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2020-minutes">2020</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2019-minutes">2019</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2018-minutes">2018</a>
+    </div>
+</div></div>
+			</div> <!-- .et_pb_code --><div class="et_pb_module et_pb_text et_pb_text_1  et_pb_text_align_left et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><h2>Board Resolutions</h2>
+<p><a href="/about/board-of-directors/board-resolutions/">View the Board Resolutions</a></p>
+<h2>Contact</h2>
+<p>Board of Directors Secretary<br/>(916) 324-1541<br/><a href="mailto:boardmembers@hsr.ca.gov">boardmembers@hsr.ca.gov</a></p>
+</div>
+			</div> <!-- .et_pb_text -->
+			</div> <!-- .et_pb_column -->
+				</div> <!-- .et_pb_row -->
+				
+			</div> <!-- .et_pb_section --><div class="et_pb_section et_pb_section_2 section-primary et_pb_with_background et_section_regular">
+				
+				
+				
+				
+					<div class="et_pb_row et_pb_row_0">
+				<div class="et_pb_column et_pb_column_4_4 et_pb_column_2  et_pb_css_mix_blend_mode_passthrough et-last-child">
+				
+				
+				<div class="et_pb_module et_pb_text et_pb_text_2  et_pb_text_align_center et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><ul class="list-inline">
+<li><a class="btn btn-secondary" href="https://registertovote.ca.gov/">Register to Vote</a></li>
+<li><a class="btn btn-secondary" href="https://www.dmv.ca.gov/portal/dmv/detail/realid">REAL ID</a></li>
+<li><a class="btn btn-secondary" href="https://www.cdph.ca.gov/covid19">COVID-19 Updates</a></li>
+<li><a class="btn btn-secondary" href="https://covid19.ca.gov/vaccines/">Vaccinate All 58</a></li>
+</ul></div>
+			</div> <!-- .et_pb_text --><div class="et_pb_module et_pb_text et_pb_text_3  et_pb_text_align_center et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><p>The California High-Speed Rail Authority makes every effort to ensure the website and its contents meet mandated ADA requirements as per the California State mandated Web Content Accessibility Guidelines 2.0 Level AA standard. If you are looking for a particular document not located on the California High-Speed Rail Authority website, you may make a request for the document under the Public Records Act through the Public Records Act page. If you have any questions about the website or its contents, please contact the Authority at <a href="mailto:info@hsr.ca.gov">info@hsr.ca.gov</a>.</p></div>
+			</div> <!-- .et_pb_text -->
+			</div> <!-- .et_pb_column -->
+				
+				
+			</div> <!-- .et_pb_row -->
+				
+				
+			</div> <!-- .et_pb_section -->		</div><!-- .et_builder_inner_content -->
+	</div><!-- .et-l -->
+	
+			
+		</div><!-- #et-boc -->
+		</div>
+					</article> <!-- .et_pb_post -->
+
+										<span class="return-top hidden-print"></span>
+				</main>
+			</div> <!-- #main-content -->
+		</div>
+	</div>
+	<footer id="footer" class="global-footer hidden-print"><div class="container footer-menu"><div class="group"><div class="three-quarters"><ul class="footer-links"><li><a href="#skip-to-content">Back to Top</a></li><li class="" title=""><a href="/conditions-of-use/">Conditions of Use</a></li><li class="" title=""><a href="/privacy-policy/">Privacy Policy</a></li><li class="" title=""><a href="/accessibility/">Accessibility</a></li><li class="" title=""><a href="/contact/">Contact Us</a></li><li class="" title=""><a href="/a-to-z-index/">A to Z Index</a></li></ul></div><div class="quarter"><ul class="socialsharer-container"><li><a href="https://www.facebook.com/CaliforniaHighSpeedRail/" title="Share via Facebook" target="_blank"><span class="ca-gov-icon-facebook"></span><span class="sr-only">facebook</span></a></li><li><a href="https://twitter.com/cahsra" title="Share via Twitter" target="_blank"><span class="ca-gov-icon-twitter"></span><span class="sr-only">twitter</span></a></li><li><a href="https://www.flickr.com/photos/hsrcagov/" title="Share via Flickr" target="_blank"><span class="ca-gov-icon-flickr"></span><span class="sr-only">flickr</span></a></li><li><a href="https://www.youtube.com/CAHighSpeedRail" title="Share via YouTube" target="_blank"><span class="ca-gov-icon-youtube"></span><span class="sr-only">youtube</span></a></li><li><a href="https://www.instagram.com/cahsra/" title="Share via Instagram" target="_blank"><span class="ca-gov-icon-instagram"></span><span class="sr-only">instagram</span></a></li><li><a href="https://www.linkedin.com/company/california-high-speed-rail-authority" title="Share via LinkedIn" target="_blank"><span class="ca-gov-icon-linkedin"></span><span class="sr-only">linkedin</span></a></li></ul></div></div></div><!-- Copyright Statement --><div class="copyright"><div class="container"><p class="d-inline">Copyright &copy; 2022 State of California</p></div></div></footer>        <div id="trp-floater-ls" onclick="" data-no-translation class="trp-language-switcher-container trp-floater-ls-names trp-bottom-right trp-color-dark">
+            <div id="trp-floater-ls-current-language" class="trp-with-flags">
+                <a href="#" class="trp-floater-ls-disabled-language trp-ls-disabled-language" onclick="event.preventDefault()">
+					<img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/en_US.png" width="18" height="12" alt="en_US" title="English" data-pagespeed-url-hash="2115649056" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">English				</a>
+            </div>
+            <div id="trp-floater-ls-language-list" class="trp-with-flags">
+                <div class="trp-language-wrap">                    <a href="https://hsr.ca.gov/es/about/board-of-directors/schedule/" title="Español de México">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/es_MX.png" width="18" height="12" alt="es_MX" title="Español de México" data-pagespeed-url-hash="1320759892" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Español de México					          </a>
+                                    <a href="https://hsr.ca.gov/ar/about/board-of-directors/schedule/" title="العربية">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ar.png" width="18" height="12" alt="ar" title="العربية" data-pagespeed-url-hash="2956364983" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">العربية					          </a>
+                                    <a href="https://hsr.ca.gov/hy/about/board-of-directors/schedule/" title="Հայերեն">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/hy.png" width="18" height="12" alt="hy" title="Հայերեն" data-pagespeed-url-hash="196385043" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Հայերեն					          </a>
+                                    <a href="https://hsr.ca.gov/hmn/about/board-of-directors/schedule/" title="Hmong">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/uploads/2021/05/hmong-16x10.png" width="18" height="12" alt="hmn" title="Hmong" data-pagespeed-url-hash="652958787" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Hmong					          </a>
+                                    <a href="https://hsr.ca.gov/zh/about/board-of-directors/schedule/" title="繁體中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_TW.png" width="18" height="12" alt="zh_TW" title="繁體中文" data-pagespeed-url-hash="181731812" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">繁體中文					          </a>
+                                    <a href="https://hsr.ca.gov/zh_hk/about/board-of-directors/schedule/" title="香港中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_HK.png" width="18" height="12" alt="zh_HK" title="香港中文" data-pagespeed-url-hash="1845292212" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">香港中文					          </a>
+                                    <a href="https://hsr.ca.gov/zh_cn/about/board-of-directors/schedule/" title="简体中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_CN.png" width="18" height="12" alt="zh_CN" title="简体中文" data-pagespeed-url-hash="3104872040" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">简体中文					          </a>
+                                    <a href="https://hsr.ca.gov/ko/about/board-of-directors/schedule/" title="한국어">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ko_KR.png" width="18" height="12" alt="ko_KR" title="한국어" data-pagespeed-url-hash="2804872994" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">한국어					          </a>
+                                    <a href="https://hsr.ca.gov/ja/about/board-of-directors/schedule/" title="日本語">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ja.png" width="18" height="12" alt="ja" title="日本語" data-pagespeed-url-hash="1567889505" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">日本語					          </a>
+                                    <a href="https://hsr.ca.gov/pa/about/board-of-directors/schedule/" title="ਪੰਜਾਬੀ">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/pa_IN.png" width="18" height="12" alt="pa_IN" title="ਪੰਜਾਬੀ" data-pagespeed-url-hash="1605722755" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">ਪੰਜਾਬੀ					          </a>
+                                    <a href="https://hsr.ca.gov/tl/about/board-of-directors/schedule/" title="Tagalog">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/tl.png" width="18" height="12" alt="tl" title="Tagalog" data-pagespeed-url-hash="4055228506" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Tagalog					          </a>
+                                    <a href="https://hsr.ca.gov/vi/about/board-of-directors/schedule/" title="Tiếng Việt">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/vi.png" width="18" height="12" alt="vi" title="Tiếng Việt" data-pagespeed-url-hash="3021296717" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Tiếng Việt					          </a>
+                <a href="#" class="trp-floater-ls-disabled-language trp-ls-disabled-language" onclick="event.preventDefault()"><img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/en_US.png" width="18" height="12" alt="en_US" title="English" data-pagespeed-url-hash="2115649056" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">English</a></div>            </div>
+        </div>
+
+    			<script>document.body.classList.remove('primary');</script>
+		<script>var $=jQuery;</script>
+
+<script src="/wp-content/custom/js/library.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.4.6/js/swiper.min.js"></script>
+<script>var swiper=new Swiper('.swiper-container',{slidesPerView:4,spaceBetween:2,loop:true,navigation:{nextEl:'.section__gallery-button--next',prevEl:'.section__gallery-button--prev',},breakpoints:{1440:{slidesPerView:3},900:{slidesPerView:2},550:{slidesPerView:1}}});</script>
+
+<script>document.addEventListener("DOMContentLoaded",function(event){document.querySelectorAll('.info-image__popup')});</script>
+
+<script type='text/javascript' id='thickbox-js-extra'>//<![CDATA[
+var thickboxL10n={"next":"Next >","prev":"< Prev","image":"Image","of":"of","close":"Close","noiframes":"This feature requires inline frames. You have iframes disabled or your browser does not support them.","loadingAnimation":"https:\/\/hsr.ca.gov\/wp-includes\/js\/thickbox\/loadingAnimation.gif"};
+//]]></script>
+<script type='text/javascript' defer src='https://hsr.ca.gov/wp-includes/js/thickbox/thickbox.js?ver=3.1-20121105' id='thickbox-js'></script>
+<script type='text/javascript' id='et-builder-modules-global-functions-script-js-extra'>//<![CDATA[
+var et_builder_utils_params={"condition":{"diviTheme":true,"extraTheme":false},"scrollLocations":["app","top"],"builderScrollLocations":{"desktop":"app","tablet":"app","phone":"app"},"onloadScrollLocation":"app","builderType":"fe"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/frontend-builder/build/frontend-builder-global-functions.js?ver=4.9.3' id='et-builder-modules-global-functions-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.mobile.custom.min.js?ver=4.9.3' id='et-jquery-touch-mobile-js'></script>
+<script type='text/javascript' id='divi-custom-script-js-extra'>//<![CDATA[
+var DIVI={"item_count":"%d Item","items_count":"%d Items"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/js/custom.js?ver=4.9.3' id='divi-custom-script-js'></script>
+<script type='text/javascript' id='et-builder-modules-script-js-extra'>//<![CDATA[
+var et_frontend_scripts={"builderCssContainerPrefix":"#et-boc","builderCssLayoutPrefix":"#et-boc .et-l"};var et_pb_custom={"ajaxurl":"https:\/\/hsr.ca.gov\/wp-admin\/admin-ajax.php","images_uri":"https:\/\/hsr.ca.gov\/wp-content\/themes\/Divi\/images","builder_images_uri":"https:\/\/hsr.ca.gov\/wp-content\/themes\/Divi\/includes\/builder\/images","et_frontend_nonce":"743ccce76d","subscription_failed":"Please, check the fields below to make sure you entered the correct information.","et_ab_log_nonce":"ce8e9ee275","fill_message":"Please, fill in the following fields:","contact_error_message":"Please, fix the following errors:","invalid":"Invalid email","captcha":"Captcha","prev":"Prev","previous":"Previous","next":"Next","wrong_captcha":"You entered the wrong number in captcha.","wrong_checkbox":"Checkbox","ignore_waypoints":"no","is_divi_theme_used":"1","widget_search_selector":".widget_search","ab_tests":[],"is_ab_testing_active":"","page_id":"10928","unique_test_id":"","ab_bounce_rate":"5","is_cache_plugin_active":"no","is_shortcode_tracking":"","tinymce_uri":""};var et_pb_box_shadow_elements=[];var et_pb_motion_elements={"desktop":[],"tablet":[],"phone":[]};var et_pb_sticky_elements=[];
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/frontend-builder/build/frontend-builder-scripts.js?ver=4.9.3' id='et-builder-modules-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/plugins/hsr-plugins/scripts/frontend-bundle.min.js?ver=1.0.0' id='symsoft-divi-extension-frontend-bundle-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/divi/extension/scripts/frontend-bundle.min.js?ver=1.0.0' id='caweb-module-extension-frontend-bundle-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.fitvids.js?ver=4.9.3' id='divi-fitvids-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/waypoints.min.js?ver=4.9.3' id='waypoints-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.magnific-popup.js?ver=4.9.3' id='magnific-popup-js'></script>
+<script type='text/javascript' id='cagov-caweb-script-js-extra'>//<![CDATA[
+var args={"ca_google_analytic_id":"UA-73985215-2","ca_google_tag_manager_id":"GTM-N6J3M4W","ca_google_tag_manager_approved":"","ca_site_version":"5","ca_frontpage_search_enabled":"","ca_google_search_id":"001779225245372747843:jso5c-pvxls","caweb_multi_ga":"","ca_google_trans_enabled":"","ajaxurl":"https:\/\/hsr.ca.gov\/wp-admin\/admin-post.php"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/js/caweb-v5.min.js?ver=5.7.7' id='cagov-caweb-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/core/admin/js/common.js?ver=4.9.3' id='et-core-common-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/caweb-1.5.0-ext/js/1/caweb-custom.js?ver=-633cd37e9d00d2.39873541' id='caweb-custom-js-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/wp-embed.js?ver=5.7.7' id='wp-embed-js'></script>
+<style id="et-builder-module-design-10928-cached-inline-styles">.et_pb_section_0.et_pb_section{padding-top:0;margin-top:0}.et_pb_column_1{padding-top:0}.et_pb_column_0{padding-top:0}.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7}.{max-width:none}.et_pb_toggle_8.et_pb_toggle h5,.et_pb_toggle_8.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_4.et_pb_toggle h5,.et_pb_toggle_4.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_5.et_pb_toggle h5,.et_pb_toggle_5.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_1.et_pb_toggle h5,.et_pb_toggle_1.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_2.et_pb_toggle h5,.et_pb_toggle_2.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_3.et_pb_toggle h5,.et_pb_toggle_3.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_6.et_pb_toggle h5,.et_pb_toggle_6.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_7.et_pb_toggle h5,.et_pb_toggle_7.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_0.et_pb_toggle h5,.et_pb_toggle_0.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_module.et_pb_toggle_6.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_7.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_8.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_toggle_2.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_8.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_4.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_5.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_7.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_0.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_6.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_3.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_1.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_8 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_4 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_7 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_6 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_5 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_3 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_2 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_1 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_0 .et_pb_toggle_title:before{color:#007fad}.et_pb_divider_0{background-color:#007fad;padding-top:7rem;margin-bottom:0!important}.et_pb_divider_0:before{border-top-color:#007fad;width:auto;top:7rem;right:0;left:0}.et_pb_ca_siblingPages_0{background-color:#007fad;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem;margin-bottom:0!important}.et_pb_image_0{margin-top:0!important;width:100%;max-width:100%!important;text-align:left;margin-left:0}.et_pb_image_0 .et_pb_image_wrap,.et_pb_image_0 img{width:100%}.et_pb_text_1 h2{font-weight:700;text-transform:uppercase;font-size:20px}.et_pb_section_2.et_pb_section{background-color:#22407d!important}.et_pb_text_3{max-width:630px}.et_pb_text_3.et_pb_module{margin-left:auto!important;margin-right:auto!important}@media only screen and (max-width:980px){.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_6.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_7.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_8.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_divider_0{padding-top:0}.et_pb_divider_0:before{width:auto;top:0;right:0;left:0}}@media only screen and (min-width:768px) and (max-width:980px){.et_pb_ca_breadcrumb_0{display:none!important}}@media only screen and (max-width:767px){.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7;display:none!important}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_6.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_7.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_8.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}}</style>		<script>$=jQuery.noConflict();var media_carousels=$('div[class*="et_pb_ca_fullwidth_section_carousel_"]:not(".item")');media_carousels.each(function(index,carousel){if($(carousel).hasClass('media')||$(carousel).hasClass('panel')){$(carousel).find('.carousel-media').owlCarousel({responsive:true,responsive:{0:{items:1,nav:true},400:{items:1,nav:true},768:{items:undefined===carousel.slide_amount?4:carousel.slide_amount,nav:true},},margin:10,nav:true,dots:false,navText:['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>','<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'],});}})</script>
+				<script>$=jQuery.noConflict();var media_carousels=$('div[class*="et_pb_ca_section_carousel_"]:not(".item")');media_carousels.each(function(index,carousel){if($(carousel).hasClass('media')||$(carousel).hasClass('panel')){$(carousel).find('.carousel-media').owlCarousel({responsive:true,responsive:{0:{items:1,nav:true},400:{items:1,nav:true},768:{items:undefined===carousel.slide_amount?4:carousel.slide_amount,nav:true},},margin:10,nav:true,dots:false,navText:['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>','<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'],});}})</script>
+		<script async type="text/javascript" src="/_Incapsula_Resource?SWJIYLWA=719d34d31c8e3a6e6fffd425f7e032f3&ns=1&cb=190130165"></script>
+</body>
+</html>
+
+<!--
+Performance optimized by W3 Total Cache. Learn more: https://www.boldgrid.com/w3-total-cache/
+
+Page Caching using disk: enhanced 
+
+Served from: hsr.ca.gov @ 2022-10-04 17:44:46 by W3 Total Cache
+-->

--- a/tests/files/ca_highspeed_rail_finance_committee.html
+++ b/tests/files/ca_highspeed_rail_finance_committee.html
@@ -1,0 +1,748 @@
+
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="Author" content="State of California"/>
+	<meta name="Description" content="State of California"/>
+	<meta name="Keywords" content="California, government"/>
+
+	<!-- http://t.co/dKP3o1e -->
+	<meta name="HandheldFriendly" content="True">
+
+	<!-- for Blackberry, AvantGo -->
+	<meta name="MobileOptimized" content="320">
+
+	<!-- for Windows mobile -->
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+	<!-- Google Meta-->
+	<meta name="google-site-verification" content="001779225245372747843:jso5c-pvxls"/>
+
+	
+	
+	<link rel="apple-touch-icon-precomposed" sizes="100x100" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-precomposed.png">
+	<link rel="apple-touch-icon-precomposed" sizes="192x192" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-192x192.png">
+	<link rel="apple-touch-icon-precomposed" sizes="180x180" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-180x180.png">
+	<link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-152x152.png">
+	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-144x144.png">
+	<link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-120x120.png">
+	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-114x114.png">
+	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon-precomposed" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-57x57.png">
+	<link rel="apple-touch-icon" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon.png">
+
+
+	<script>var et_site_url='https://hsr.ca.gov';var et_post_id='9600';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}</script><title>Finance &amp; Audit Committee &#x2d; California High Speed Rail</title>
+<meta name='robots' content='max-image-preview:large'/>
+
+<!-- The SEO Framework by Sybre Waaijer -->
+<meta name="robots" content="max-snippet:-1,max-image-preview:standard,max-video-preview:-1"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:type" content="website"/>
+<meta property="og:title" content="Finance &amp; Audit Committee &#x2d; California High Speed Rail"/>
+<meta property="og:url" content="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/"/>
+<meta property="og:site_name" content="California High Speed Rail"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Finance &amp; Audit Committee &#x2d; California High Speed Rail"/>
+<link rel="canonical" href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/"/>
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item": {
+                "@id": "https://hsr.ca.gov/",
+                "name": "California High Speed Rail"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/",
+                "name": "About"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/board-of-directors/",
+                "name": "Board of Directors"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 4,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/",
+                "name": "Finance &amp; Audit Committee"
+            }
+        }
+    ]
+}</script>
+<!-- / The SEO Framework by Sybre Waaijer | 9.47ms meta | 0.53ms boot -->
+
+<link rel='dns-prefetch' href='//fonts.googleapis.com'/>
+<link rel='dns-prefetch' href='//s.w.org'/>
+<link rel="alternate" type="application/rss+xml" title="California High Speed Rail &raquo; Feed" href="https://hsr.ca.gov/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="California High Speed Rail &raquo; Comments Feed" href="https://hsr.ca.gov/comments/feed/"/>
+		<script type="text/javascript">window._wpemojiSettings={"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/svg\/","svgExt":".svg","source":{"wpemoji":"https:\/\/hsr.ca.gov\/wp-includes\/js\/wp-emoji.js?ver=5.7.7","twemoji":"https:\/\/hsr.ca.gov\/wp-includes\/js\/twemoji.js?ver=5.7.7"}};(function(window,document,settings){var src,ready,ii,tests;var canvas=document.createElement('canvas');var context=canvas.getContext&&canvas.getContext('2d');function emojiSetsRenderIdentically(set1,set2){var stringFromCharCode=String.fromCharCode;context.clearRect(0,0,canvas.width,canvas.height);context.fillText(stringFromCharCode.apply(this,set1),0,0);var rendered1=canvas.toDataURL();context.clearRect(0,0,canvas.width,canvas.height);context.fillText(stringFromCharCode.apply(this,set2),0,0);var rendered2=canvas.toDataURL();return rendered1===rendered2;}function browserSupportsEmoji(type){var isIdentical;if(!context||!context.fillText){return false;}context.textBaseline='top';context.font='600 32px Arial';switch(type){case'flag':isIdentical=emojiSetsRenderIdentically([0x1F3F3,0xFE0F,0x200D,0x26A7,0xFE0F],[0x1F3F3,0xFE0F,0x200B,0x26A7,0xFE0F]);if(isIdentical){return false;}isIdentical=emojiSetsRenderIdentically([0xD83C,0xDDFA,0xD83C,0xDDF3],[0xD83C,0xDDFA,0x200B,0xD83C,0xDDF3]);if(isIdentical){return false;}isIdentical=emojiSetsRenderIdentically([0xD83C,0xDFF4,0xDB40,0xDC67,0xDB40,0xDC62,0xDB40,0xDC65,0xDB40,0xDC6E,0xDB40,0xDC67,0xDB40,0xDC7F],[0xD83C,0xDFF4,0x200B,0xDB40,0xDC67,0x200B,0xDB40,0xDC62,0x200B,0xDB40,0xDC65,0x200B,0xDB40,0xDC6E,0x200B,0xDB40,0xDC67,0x200B,0xDB40,0xDC7F]);return!isIdentical;case'emoji':isIdentical=emojiSetsRenderIdentically([0xD83D,0xDC68,0x200D,0xD83C,0xDF7C],[0xD83D,0xDC68,0x200B,0xD83C,0xDF7C]);return!isIdentical;}return false;}function addScript(src){var script=document.createElement('script');script.src=src;script.defer=script.type='text/javascript';document.getElementsByTagName('head')[0].appendChild(script);}tests=Array('flag','emoji');settings.supports={everything:true,everythingExceptFlag:true};for(ii=0;ii<tests.length;ii++){settings.supports[tests[ii]]=browserSupportsEmoji(tests[ii]);settings.supports.everything=settings.supports.everything&&settings.supports[tests[ii]];if('flag'!==tests[ii]){settings.supports.everythingExceptFlag=settings.supports.everythingExceptFlag&&settings.supports[tests[ii]];}}settings.supports.everythingExceptFlag=settings.supports.everythingExceptFlag&&!settings.supports.flag;settings.DOMReady=false;settings.readyCallback=function(){settings.DOMReady=true;};if(!settings.supports.everything){ready=function(){settings.readyCallback();};if(document.addEventListener){document.addEventListener('DOMContentLoaded',ready,false);window.addEventListener('load',ready,false);}else{window.attachEvent('onload',ready);document.attachEvent('onreadystatechange',function(){if('complete'===document.readyState){settings.readyCallback();}});}src=settings.source||{};if(src.concatemoji){addScript(src.concatemoji);}else if(src.wpemoji&&src.twemoji){addScript(src.twemoji);addScript(src.wpemoji);}}})(window,document,window._wpemojiSettings);</script>
+		<meta content="CAWeb v.1.5.0" name="generator"/><style type="text/css">img.wp-smiley,img.emoji{display:inline!important;border:none!important;box-shadow:none!important;height:1em!important;width:1em!important;margin:0 .07em!important;vertical-align:-.1em!important;background:none!important;padding:0!important}</style>
+	<link rel='stylesheet' id='dashicons-css' href='https://hsr.ca.gov/wp-includes/css/dashicons.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='thickbox-css' href='https://hsr.ca.gov/wp-includes/js/thickbox/thickbox.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='wp-block-library-css' href='https://hsr.ca.gov/wp-includes/css/dist/block-library/style.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='trp-floater-language-switcher-style-css' href='https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/css/trp-floater-language-switcher.css?ver=2.0.1' type='text/css' media='all'/>
+<link rel='stylesheet' id='trp-language-switcher-style-css' href='https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/css/trp-language-switcher.css?ver=2.0.1' type='text/css' media='all'/>
+<link rel='stylesheet' id='parent-style-css' href='https://hsr.ca.gov/wp-content/themes/Divi/style.dev.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='divi-style-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/style.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='symsoft-divi-extension-styles-css' href='https://hsr.ca.gov/wp-content/plugins/hsr-plugins/styles/style.min.css?ver=1.0.0' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-module-extension-styles-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/divi/extension/styles/style.min.css?ver=1.0.0' type='text/css' media='all'/>
+<link rel='stylesheet' id='et-builder-googlefonts-cached-css' href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200italic,300,300italic,regular,italic,600,600italic,700,700italic,900,900italic&#038;subset=latin,latin-ext&#038;display=swap' type='text/css' media='all'/>
+<link rel='stylesheet' id='tablepress-default-css' href='https://hsr.ca.gov/wp-content/plugins/tablepress/css/default.css?ver=1.13' type='text/css' media='all'/>
+<link rel='stylesheet' id='tablepress-responsive-tables-css' href='https://hsr.ca.gov/wp-content/plugins/tablepress-responsive-tables/css/tablepress-responsive.css?ver=1.8' type='text/css' media='all'/>
+<link rel='stylesheet' id='et-shortcodes-responsive-css-css' href='https://hsr.ca.gov/wp-content/themes/Divi/epanel/shortcodes/css/shortcodes_responsive.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='magnific-popup-css' href='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/styles/magnific_popup.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-core-style-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/css/cagov-v5-oceanside.min.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='cagov-google-font-style-css' href='https://fonts.googleapis.com/css?family=Asap+Condensed%3A400%2C600%7CSource+Sans+Pro%3A400%2C700&#038;ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-custom-css-styles-css' href='https://hsr.ca.gov/wp-content/caweb-1.5.0-ext/css/1/caweb-custom.css?ver=-6340b2c4879e35.61684599' type='text/css' media='all'/>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/jquery/jquery.js?ver=3.5.1' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/jquery/jquery-migrate.js?ver=3.3.2' id='jquery-migrate-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/plugins/wpo365-login/apps/dist/pintra-redirect.js?ver=12.11' id='pintraredirectjs-js'></script>
+<script type='text/javascript' defer src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/js/libs/modernizr-3.6.0.min.js?ver=5.7.7' id='cagov-modernizr-script-js'></script>
+<link rel="https://api.w.org/" href="https://hsr.ca.gov/wp-json/"/><link rel="alternate" type="application/json" href="https://hsr.ca.gov/wp-json/wp/v2/pages/9600"/><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://hsr.ca.gov/xmlrpc.php?rsd"/>
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://hsr.ca.gov/wp-includes/wlwmanifest.xml"/> 
+<link rel="alternate" type="application/json+oembed" href="https://hsr.ca.gov/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fhsr.ca.gov%2Fabout%2Fboard-of-directors%2Ffinance-audit-committee%2F"/>
+<link rel="alternate" type="text/xml+oembed" href="https://hsr.ca.gov/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fhsr.ca.gov%2Fabout%2Fboard-of-directors%2Ffinance-audit-committee%2F&#038;format=xml"/>
+<link rel="alternate" hreflang="en-US" href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="en" href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="es-MX" href="https://hsr.ca.gov/es/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="es" href="https://hsr.ca.gov/es/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="ar" href="https://hsr.ca.gov/ar/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="hy" href="https://hsr.ca.gov/hy/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="hmn" href="https://hsr.ca.gov/hmn/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="zh-TW" href="https://hsr.ca.gov/zh/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="zh" href="https://hsr.ca.gov/zh/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="zh-HK" href="https://hsr.ca.gov/zh_hk/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="zh-CN" href="https://hsr.ca.gov/zh_cn/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="ko-KR" href="https://hsr.ca.gov/ko/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="ko" href="https://hsr.ca.gov/ko/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="ja" href="https://hsr.ca.gov/ja/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="pa-IN" href="https://hsr.ca.gov/pa/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="pa" href="https://hsr.ca.gov/pa/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="tl" href="https://hsr.ca.gov/tl/about/board-of-directors/finance-audit-committee/"/>
+<link rel="alternate" hreflang="vi" href="https://hsr.ca.gov/vi/about/board-of-directors/finance-audit-committee/"/>
+<script>(function($){$(window).bind("load",function(){$('.fluid-width-video-wrapper').each(function(){var src=$(this).find('iframe').attr('src');$(this).find('iframe').attr('src',src+'&amp;rel=0');});});})(jQuery)</script>
+
+<link title="Fav Icon" rel="icon" href="https://hsr.ca.gov/wp-content/uploads/2020/12/favicon.ico">
+<link rel="shortcut icon" href="https://hsr.ca.gov/wp-content/uploads/2020/12/favicon.ico">
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/><link rel="preload" href="https://hsr.ca.gov/wp-content/themes/Divi/core/admin/fonts/modules.ttf" as="font" crossorigin="anonymous"><link rel="shortcut icon" href=""/><style type="text/css">.broken_link,a.broken_link{text-decoration:line-through}</style><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.4.6/css/swiper.min.css"><link rel="stylesheet" id="et-divi-customizer-global-cached-inline-styles" href="https://hsr.ca.gov/wp-content/et-cache/1/1/global/et-divi-customizer-global-16595570436405.min.css" onerror="et_core_page_resource_fallback(this, true)" onload="et_core_page_resource_fallback(this)"/>
+
+</head>
+<body class="page-template-default page page-id-9600 page-parent page-child parent-pageid-1126 primary translatepress-en_US et_pb_button_helper_class et_header_style_left et_pb_footer_columns4 et_cover_background et_pb_gutter osx et_pb_gutters3 et_pb_pagebuilder_layout et_no_sidebar et_divi_theme et-db divi_builder title_not_displayed v5 sidebar_not_displayed ">
+	<!-- Google Tag Manager (noscript) -->
+<noscript>
+	<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6J3M4W" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+			
+
+<header id="header" class="global-header">
+	<div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+	<!-- Alert Banners -->
+<!-- Utility Header -->
+<div class="utility-header hidden-print">
+	<div class="container">
+		<div class="group flex-row">
+			<div class="social-media-links">
+				<div class="header-cagov-logo">
+					<a href="https://www.ca.gov/" title="CA.gov website">
+						<span class="sr-only">CA.gov</span>
+						<script data-pagespeed-no-defer>//<![CDATA[
+(function(){for(var g="function"==typeof Object.defineProperties?Object.defineProperty:function(b,c,a){if(a.get||a.set)throw new TypeError("ES3 does not support getters and setters.");b!=Array.prototype&&b!=Object.prototype&&(b[c]=a.value)},h="undefined"!=typeof window&&window===this?this:"undefined"!=typeof global&&null!=global?global:this,k=["String","prototype","repeat"],l=0;l<k.length-1;l++){var m=k[l];m in h||(h[m]={});h=h[m]}var n=k[k.length-1],p=h[n],q=p?p:function(b){var c;if(null==this)throw new TypeError("The 'this' value for String.prototype.repeat must not be null or undefined");c=this+"";if(0>b||1342177279<b)throw new RangeError("Invalid count value");b|=0;for(var a="";b;)if(b&1&&(a+=c),b>>>=1)c+=c;return a};q!=p&&null!=q&&g(h,n,{configurable:!0,writable:!0,value:q});var t=this;function u(b,c){var a=b.split("."),d=t;a[0]in d||!d.execScript||d.execScript("var "+a[0]);for(var e;a.length&&(e=a.shift());)a.length||void 0===c?d[e]?d=d[e]:d=d[e]={}:d[e]=c};function v(b){var c=b.length;if(0<c){for(var a=Array(c),d=0;d<c;d++)a[d]=b[d];return a}return[]};function w(b){var c=window;if(c.addEventListener)c.addEventListener("load",b,!1);else if(c.attachEvent)c.attachEvent("onload",b);else{var a=c.onload;c.onload=function(){b.call(this);a&&a.call(this)}}};var x;function y(b,c,a,d,e){this.h=b;this.j=c;this.l=a;this.f=e;this.g={height:window.innerHeight||document.documentElement.clientHeight||document.body.clientHeight,width:window.innerWidth||document.documentElement.clientWidth||document.body.clientWidth};this.i=d;this.b={};this.a=[];this.c={}}function z(b,c){var a,d,e=c.getAttribute("data-pagespeed-url-hash");if(a=e&&!(e in b.c))if(0>=c.offsetWidth&&0>=c.offsetHeight)a=!1;else{d=c.getBoundingClientRect();var f=document.body;a=d.top+("pageYOffset"in window?window.pageYOffset:(document.documentElement||f.parentNode||f).scrollTop);d=d.left+("pageXOffset"in window?window.pageXOffset:(document.documentElement||f.parentNode||f).scrollLeft);f=a.toString()+","+d;b.b.hasOwnProperty(f)?a=!1:(b.b[f]=!0,a=a<=b.g.height&&d<=b.g.width)}a&&(b.a.push(e),b.c[e]=!0)}y.prototype.checkImageForCriticality=function(b){b.getBoundingClientRect&&z(this,b)};u("pagespeed.CriticalImages.checkImageForCriticality",function(b){x.checkImageForCriticality(b)});u("pagespeed.CriticalImages.checkCriticalImages",function(){A(x)});function A(b){b.b={};for(var c=["IMG","INPUT"],a=[],d=0;d<c.length;++d)a=a.concat(v(document.getElementsByTagName(c[d])));if(a.length&&a[0].getBoundingClientRect){for(d=0;c=a[d];++d)z(b,c);a="oh="+b.l;b.f&&(a+="&n="+b.f);if(c=!!b.a.length)for(a+="&ci="+encodeURIComponent(b.a[0]),d=1;d<b.a.length;++d){var e=","+encodeURIComponent(b.a[d]);131072>=a.length+e.length&&(a+=e)}b.i&&(e="&rd="+encodeURIComponent(JSON.stringify(B())),131072>=a.length+e.length&&(a+=e),c=!0);C=a;if(c){d=b.h;b=b.j;var f;if(window.XMLHttpRequest)f=new XMLHttpRequest;else if(window.ActiveXObject)try{f=new ActiveXObject("Msxml2.XMLHTTP")}catch(r){try{f=new ActiveXObject("Microsoft.XMLHTTP")}catch(D){}}f&&(f.open("POST",d+(-1==d.indexOf("?")?"?":"&")+"url="+encodeURIComponent(b)),f.setRequestHeader("Content-Type","application/x-www-form-urlencoded"),f.send(a))}}}function B(){var b={},c;c=document.getElementsByTagName("IMG");if(!c.length)return{};var a=c[0];if(!("naturalWidth"in a&&"naturalHeight"in a))return{};for(var d=0;a=c[d];++d){var e=a.getAttribute("data-pagespeed-url-hash");e&&(!(e in b)&&0<a.width&&0<a.height&&0<a.naturalWidth&&0<a.naturalHeight||e in b&&a.width>=b[e].o&&a.height>=b[e].m)&&(b[e]={rw:a.width,rh:a.height,ow:a.naturalWidth,oh:a.naturalHeight})}return b}var C="";u("pagespeed.CriticalImages.getBeaconData",function(){return C});u("pagespeed.CriticalImages.Run",function(b,c,a,d,e,f){var r=new y(b,c,a,e,f);x=r;d&&w(function(){window.setTimeout(function(){A(r)},0)})});})();pagespeed.CriticalImages.Run('/mod_pagespeed_beacon','https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/','8Xxa2XQLv9',true,false,'3Jqg6O0P31o');
+//]]></script><img style="height: 31px;" src="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/logo.svg" class="pos-rel" alt="CA.gov website" aria-hidden="true" data-pagespeed-url-hash="3038728008" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/>
+					</a>
+				</div>
+
+									<a href="/" title="Home" class="utility-home-icon ca-gov-icon-home"><span class="sr-only">Home</span></a>
+											<a class="utility-social-facebook ca-gov-icon-facebook" href="https://www.facebook.com/CaliforniaHighSpeedRail/" title="Share via Facebook" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Facebook</span>
+						</a>
+												<a class="utility-social-twitter ca-gov-icon-twitter" href="https://twitter.com/cahsra" title="Share via Twitter" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Twitter</span>
+						</a>
+												<a class="utility-social-flickr ca-gov-icon-flickr" href="https://www.flickr.com/photos/hsrcagov/" title="Share via Flickr" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Flickr</span>
+						</a>
+												<a class="utility-social-youtube ca-gov-icon-youtube" href="https://www.youtube.com/CAHighSpeedRail" title="Share via YouTube" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via YouTube</span>
+						</a>
+												<a class="utility-social-instagram ca-gov-icon-instagram" href="https://www.instagram.com/cahsra/" title="Share via Instagram" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Instagram</span>
+						</a>
+												<a class="utility-social-linkedin ca-gov-icon-linkedin" href="https://www.linkedin.com/company/california-high-speed-rail-authority" title="Share via LinkedIn" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via LinkedIn</span>
+						</a>
+									</div>
+			<div class="settings-links">
+				<a class="utility-custom-1" href="/wp-content/uploads/docs/about/SIMM_25B_Web_Accessibility_Cert.pdf">ADA Certification</a><a class="utility-custom-2" href="/a-to-z-index/">A to Z Index</a>								<a class="utility-contact-us" href="/contact/">Contact Us</a>
+				
+												<button class="btn btn-xs btn-primary collapsed" data-toggle="collapse" data-target="#siteSettings" aria-controls="siteSettings">
+					<span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="site-settings section section-standout collapse collapsed" aria-atomic="true" role="alert" id="siteSettings">
+	<div class="container  p-y">
+		<div class="btn-group btn-group-justified-sm" role="group" aria-label="contrastMode">
+			<div class="btn-group"><button type="button" class="btn btn-standout disableHighContrastMode">Default</button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High Contrast</button></div>
+		</div>
+
+		<div class="btn-group" role="group" aria-label="textSizeMode">
+			<div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <span class="sr-only">Increase</span><span class="ca-gov-icon-plus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <span class="sr-only">Decrease</span><span class="ca-gov-icon-minus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+		</div>
+		<button type="button" class="close" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	</div>
+</div>
+<!-- Branding -->
+<div class="branding">
+	<div class="header-organization-banner">
+		<a href="/">
+			<img src="https://hsr.ca.gov/wp-content/uploads/2021/05/HSR_Logo_80px_height.png" alt="CA High-Speed Rail Authority Logo" data-pagespeed-url-hash="62514589" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/>
+		</a>
+	</div>
+</div>
+<!-- mobile navigation controls -->
+<div class="mobile-controls">
+    <span class="mobile-control-group mobile-header-icons">
+        <!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+    <div class="mobile-control-group main-nav-icons">
+                <button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+                <button id="nav-icon3" class="mobile-control toggle-menu" aria-expanded="false" aria-controls="navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+
+    </div>
+</div>
+
+	<div class="navigation-search">
+
+		<!-- Version 4 top-right search box always displayed -->
+		<!-- Version 5.0 fade in/out search box displays on front page and if option is enabled -->
+		<!-- Include Navigation -->
+		<nav id="navigation" class="main-navigation singlelevel hidden-print">
+                                <ul id="nav_list" class="top-level-nav"><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor  " title=""><a href="https://hsr.ca.gov/about/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">About</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/programs/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Programs</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/high-speed-rail-in-california/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">High-Speed Rail in California</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/business-opportunities/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Business Opportunities</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/jobs/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Jobs</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/communications-outreach/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Communications &amp; Outreach</span></a></li><li class="nav-item" id="nav-item-search"><button class="first-level-link h-auto"><span class="ca-gov-icon-search" aria-hidden="true"></span> Search</button></li></ul></nav>		<div id="head-search" class="search-container hidden-print" role="region" aria-label="Search Expanded">
+			<div class="container">
+	<form id="Search" class="pos-rel" action="https://hsr.ca.gov/serp">
+		<span class="sr-only" id="SearchInput">Custom Google Search</span>
+		<input type="text" id="q" name="q" value="" aria-labelledby="SearchInput" placeholder="Search this website" class="search-textfield height-50 border-0 p-x-sm w-100"/>
+		<button type="submit" class="pos-abs gsc-search-button top-0 width-50 height-50 border-0 bg-transparent">
+			<span class="ca-gov-icon-search font-size-30 color-gray"></span>
+			<span class="sr-only">Submit</span>
+		</button>
+		<div class="width-50 height-50 close-search-btn">
+			<!-- Some Google styles add an 'x' background image when button has 'gsc-clear-button' in the class -->
+			<button class="close-search width-50 height-50 border-0 bg-transparent pos-rel" type="reset">
+				<span class="sr-only">Close Search</span>
+				<span class="ca-gov-icon-close-mark"></span>
+			</button>
+		</div>
+	</form>
+</div>
+		</div>
+	</div>
+</header>
+
+	<div id="page-container">
+		<div id="et-main-area">
+
+			<div id="main-content" class="main-content" tabindex="-1">
+				<main class="main-primary">
+
+					
+					<article id="post-9600" class="post-9600 page type-page status-publish hentry">
+
+						<div class="entry-content"><div id="et-boc" class="et-boc">
+			
+		<div class="et-l et-l--post">
+			<div class="et_builder_inner_content et_pb_gutters3">
+		<div class="et_pb_section et_pb_section_0 et_section_specialty">
+				
+				
+				
+				<div class="et_pb_row">
+					<div class="et_pb_column et_pb_column_2_3 et_pb_column_0   et_pb_specialty_column  et_pb_css_mix_blend_mode_passthrough">
+				
+				
+				<div class="et_pb_row_inner et_pb_row_inner_0">
+				<div class="et_pb_column et_pb_column_4_4 et_pb_column_inner et_pb_column_inner_0 et-last-child">
+				
+				
+				<div class="et_pb_with_border et_pb_module et_pb_ca_breadcrumb et_pb_ca_breadcrumb_0">
+				
+				
+				
+				
+				<div class="et_pb_module_inner">
+					<ol class="breadcrumb"><li><a href="/" title="home">Home</a></li><li><a href="https://hsr.ca.gov/about/" title="About">About</a></li><li><a href="https://hsr.ca.gov/about/board-of-directors/" title="Board of Directors">Board of Directors</a></li><li>Finance &amp; Audit Committee</li></ol>
+				</div>
+			</div><div class="et_pb_module et_pb_text et_pb_text_0  et_pb_text_align_left et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><h1>Finance &amp; Audit Committee</h1>
+<p><em>The Finance and Audit Committee</em> is a subcommittee of the Board of Directors. Its meetings are generally held prior to Board of Directors meetings once a month. These meetings are open to the public</p>
+<p>Click the following link for agendas and materials for the <a href="https://hsr.ca.gov/about/board-of-directors/schedule/">Board of Directors meetings</a>.</p></div>
+			</div> <!-- .et_pb_text --><div class="et_pb_module et_pb_toggle et_pb_toggle_0 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">September 15, 2022</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/08/15/finance-and-audit-committee-agenda/">September 15, 2022 Finance &amp; Audit Committee Agenda</a></li>
+<li><a href="https://youtu.be/OYerQMqeJYM">September 15, 2022 Finance &amp; Audit Committee Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the August 18, 2022, Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/F-and-A-Committee-Meeting-Minutes-September-2022-A11Y.pdf">August 18, 2022, Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #3 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Executive-Summary-September-2022-A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/AP-Aging-and-Disputes-Report-September-2022-A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Cash-Management-Report-September-2022-A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Administrative-Budget-and-Expenditures-September_2022v6-A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Capital-Outlay-Budget-and-Expenditures-Report-September-2022-A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Total-Project-Expenditures-with-Forecast-September-2022-A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/Contracts-Expenditures-Report-September-2022-A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Agenda Item #4 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/09/CVSR-2209-2207-Data-FINAL-V0-A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_1 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">August 18, 2022</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Finance-and-Audit-Committee-Agenda-August-2022-v1-A11Y.pdf" target="_blank" rel="noopener">August 18, 2022 Finance &amp; Audit Committee Agenda</a></li>
+<li><a href="https://youtu.be/MctOvC76xjw">August 18, 2022 Finance &amp; Audit Committee Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the March 17, 2022 Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/F-and-A-Committee-Meeting-Minutes-20220401-A11Y.pdf">March 17, 2022 Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 F&amp;A Committee Chairperson’s Remarks, Initiatives and Updates</p>
+<p>Agenda Item #3 Audit Update by Chief Auditor</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Data-Validation-Transmittal-Final-Report-June-2022-A11Y.pdf">Memo: Data Validation and Grant Management</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Data-Validation-Final-Report-June-2022-A11Y.pdf">Data Validation Audit</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Grant-Management-Audit-Report-June-2022-A11Y.pdf">Grant Management Audit</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Contract-Management-Audit-Report-August-2022-A11Y.pdf">Contract Management</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Project-Commitment-Audit-Final-Report-August-2022-A11Y.pdf">Project Commitments Audit </a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Preaward-Results-Memo-HSR-21-17-August-2022-A11Y.pdf">Pre-award Memo HSR21-17 Project Delivery Support</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Preaward-Results-Memo-HSR-22-01-Locally-Generated-Alternative-August-2022-A11Y.pdf">Pre-award Memo HSR22-01 LGA Design Services</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Preaward-Memo-HSR-22-02-Merced_to_Madera-August-2022-A11Y.pdf">Pre-award Memo HSR22-02 Merced-Madera Design Services</a></li>
+</ul>
+<p>Agenda Item #4 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Executive-Summary-August-2022-v2-A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/AP-Aging-and-Disputes-August-2022-A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Cash-Management-Report-August-2022-A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Administrative-Budget-and-Expenditures-August_2022v4-A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Capital-Outlay-Budget-and-Expenditures-Report-August-2022-A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Total-Project-Expenditures-with-Forecast-August-2022-A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/Contracts-Expenditures-Report-August-2022-A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Agenda Item #5 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/08/CVSR_2208_2206_Data-FINAL-V0-ADA.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_2 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">July 21, 2022 (CANCELED)</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Finance_and_Audit_Committee_Agenda_July-2022-v2-A11Y.pdf">July 21, 2022 Finance &amp; Audit Committee Agenda</a></li>
+</ul>
+<p>Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Executive_Summary_July-2022-v2-A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/AP-Aging-and-Disputes-Report-July-2022-A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Cash-Management-Report-July-2022-A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Administrative-Budget-and-Expenditures-July_2022-v5-A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Capital-Outlay-Budget-and-Expenditures-Report-July-2022-A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Total-Project-Expenditures-with-Forecast-July-2022-A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/Contracts-Expenditures-Report-July-2022-A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/07/CVSR-2207-2205-Data-FINAL-V0-A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_3 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">June 16, 2022 </h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/05/01/finance-and-audit-committee-meeting-061622/">June 16, 2022 Finance and Audit Committee Meeting Agenda</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the March 17, 2022 Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/F-and-A-Committee-Meeting-Minutes-20220401-A11Y.pdf">March 17, 2022 Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 F&amp;A Committee Chairperson’s Remarks, Initiatives and Updates</p>
+<p>Agenda Item #3 Data Validation and Grant Management</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Data-Validation-Transmittal-Final-Report-June-2022-A11Y.pdf">Memo: Data Validation and Grant Management</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Data-Validation-Final-Report-June-2022-A11Y.pdf">Data Validation Audit</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Grant-Management-Audit-Report-June-2022-A11Y.pdf">Grant Management Audit</a></li>
+</ul>
+<p>Agenda Item #4 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Executive-Summary-June-2022-v4-A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/AP-Aging-and-Disputes-Report-June-2022-v3-A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Cash-Management-Report-June-2022-A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Administrative-Budget-and-Expenditures-June-2022-v2-A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Capital-Outlay-Budget-and-Expenditures-Report-June-2022-A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Total-Project-Expenditures-with-Forecast-June-2022-A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/Contracts-Expenditures-Report-June-2022-FINAL-v2-A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Agenda Item #5 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/06/CVSR-2206-2204-Data-FINAL-V0-A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_4 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">May 19, 2022 (CANCELED)</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/05/09/finance-and-audit-committee-meeting/">May 19, 2022 Finance and Audit Committee Meeting Agenda (CANCELED)</a></li>
+</ul>
+<p>Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Executive-Summary-May-2022-v3-A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/AP-Aging-and-Disputes-Report-May-2022-A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Cash-Management-Report-May-2022-A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Administrative_Budget_and_Expenditures-May_2022-v3.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Capital-Outlay-Budget-and-Expenditures-Report-May-2022-A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Total-Project-Expenditures-with-Forecast-May-2022-A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/Contracts-Expenditures-Report-May-2022-A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/05/CVSR-2205-2203-Data-FINAL-A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_5 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">April 27, 2022 (CANCELED)</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Finance-and-Audit-Committee-Agenda-CANCELED-20220401.pdf">April 27, 2022 Finance and Audit Committee Meeting Agenda (CANCELED)</a></li>
+<li><a href="https://hsr.ca.gov/2022/04/15/finance-and-audit-committee-meeting-042722/">April 27, 2022 Finance and Audit Committee Meeting Agenda</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the March 17, 2022 Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/F-and-A-Committee-Meeting-Minutes-20220401-A11Y.pdf">March 17, 2022 Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 F&amp;A Committee Chairperson’s Remarks, Initiatives and Updates</p>
+<p>Agenda Item #3 Data Validation and Grant Management</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Data-Validation-Final-Report-2022-April-A11Y.pdf">Data Validation Audit</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Grant-Management-Audit-Report-2022-April-A11Y.pdf">Grant Management Audit</a></li>
+</ul>
+<p>Agenda Item #4 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Executive-Summary-April-2022-v2-A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/AP-Aging-and-Disputes-Report-20220401-A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Cash-Management-Report-20220401-A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Administrative-Budget-and-Expenditures-20220401-v02-A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Capital-Outlay-Budget-and-Expenditures-Report-20220401-A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Total-Project-Expenditures-with-Forecast-20220401-A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/Contracts-Expenditures-Report-20220401-A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Agenda Item #5 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/04/CVSR-2204-2202-Data-FINAL-v0-A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_6 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 17, 2022</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/03/07/finance-audit-committee-031722/">March 17, 2022 Finance and Audit Committee Meeting Agenda</a></li>
+<li><a href="https://youtu.be/BCF-SR08GRw">March 17, 2022 Finance And Audit Committee Meeting Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the February 17, 2022 Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/F_and_A_Committee_Meeting_Minutes-March-2022_A11Y.pdf">February 17, 2022 Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 F&amp;A Committee Chairperson’s Remarks, Initiatives and Updates</p>
+<p>Agenda Item #3 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Executive_Summary_March_2022_A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/AP_Aging_and_Disputes_Report_March-2022_A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Cash_Management_Report_March-2022_A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Administrative_Budget_and_Expenditures_March_2022_A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Capital_Outlay_Budget_and_Expenditures_Report-March-2022_A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Total_Project_Expenditures_with_Forecast-March-2022_A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/Contracts_Expenditures_Report-March_2022_A11Y.pdf">Contracts Expenditures Report</a><span class="sr-only">PDF Document</span></li>
+</ul>
+<p>Agenda Item #4 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/03/CVSR_2203_2201_Data-FINAL_V0_A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_7 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">February 17, 2022</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/02/07/finance-and-audit-committee-meeting/">February 17, 2022 Finance and Audit Committee Meeting Agenda</a></li>
+<li><a href="https://youtu.be/gIn02ru9XCI">February 17, 2022 Finance and Audit Committee Meeting Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the January 19, 2022 Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/F_and_A_Committee_Meeting_Minutes-February-2022_A11Y.pdf">January 19, 2022 Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 F&amp;A Committee Chairperson’s Remarks, Initiatives and Updates</p>
+<p>Agenda Item #3 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Executive_Summary_February-2022_v3_A11Y.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/AP_Aging_and_Disputes_Report_February-2022_A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Cash_Management_Report_Febuary-2022_A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Administrative_Budget_and_Expenditures-February-2022_A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Capital_Outlay_Budget_and_Expenditures_Report-February-2022_A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Total_Project_Expenditures_with_Forecast-February-2022_A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/Contracts_Expenditures_Report-February-2022_A11Y.pdf">Contracts Expenditures Report</a><a href="https://hsr.ca.gov/wp-content/uploads/2021/12/Contracts_Expenditures_Report-December_2021_FINAL_A11Y.pdf"><span class="sr-only">PDF Document</span></a></li>
+</ul>
+<p>Agenda Item #4 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/02/CVSR_2202_2112_Data-FINAL_V0_ADA.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_8 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">January 19, 2022</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/2022/01/07/california-high-speed-rail-finance-and-audit-committee-agenda-011922/">January 19, 2022 Finance and Audit Committee Meeting Agenda</a></li>
+<li><a href="https://youtu.be/KC9RnOWXzS4">January 19, 2022 Finance and Audit Committee Video</a></li>
+</ul>
+<p>Agenda Item #1 Consider Approving the December 16, 2021 Finance and Audit Committee Meeting Minutes</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/F_and_A_Committee_Meeting_Minutes_January-2022_A11Y.pdf">December 16, 2021 Finance and Audit Committee Meeting Minutes</a></li>
+</ul>
+<p>Agenda Item #2 F&amp;A Committee Chairperson’s Remarks, Initiatives and Updates</p>
+<p>Agenda Item #3 Executive Summary by Chief Financial Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Executive_Summary_January-2022.pdf">Financial Reports Executive Summary</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/AP_Aging_and_Disputes_January-2022_v2_A11Y.pdf">Accounts Payable Aging and Disputes Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Cash_Management_Report_January-2022_A11Y.pdf">Cash Management Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Administrative_Budget_and_Expenditures-January_2022_v3_A11Y.pdf">Administrative Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Capital_Outlay_Budget_and_Expenditures_Report-January-2022_A11Y.pdf">Capital Outlay Budget and Expenditures Report</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Total_Project_Expenditures_with_Forecast-January-2022_A11Y.pdf">Total Project Expenditures with Forecasts</a></li>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/Contracts_Expenditures_Report-January_2022_FINAL_v2_A11Y.pdf">Contracts Expenditures Report</a><a href="https://hsr.ca.gov/wp-content/uploads/2021/12/Contracts_Expenditures_Report-December_2021_FINAL_A11Y.pdf"><span class="sr-only">PDF Document</span></a></li>
+</ul>
+<p>Agenda Item #4 Central Valley Update by Chief Operating Officer</p>
+<ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2022/01/CVSR_2201_2111_Data-FINAL_V0_A11Y.pdf">Central Valley Status Report</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle -->
+			</div> <!-- .et_pb_column -->
+				
+				
+			</div> <!-- .et_pb_row_inner -->
+			</div> <!-- .et_pb_column --><div class="et_pb_column et_pb_column_1_3 et_pb_column_1    et_pb_css_mix_blend_mode_passthrough">
+				
+				
+				<div class="et_pb_module et_pb_divider et_pb_divider_0 et_pb_divider_position_ et_pb_space"><div class="et_pb_divider_internal"></div></div><div class="et_pb_module et_pb_ca_siblingPages et_pb_ca_siblingPages_0">
+				
+				
+				
+				
+				<div class="et_pb_module_inner">
+					<ul><li class="page_item page-item-26608"><a href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/2021-finance-audit-committee-meetings/">2021 Finance &amp; Audit Committee Meetings</a><li class="page_item page-item-16766"><a href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/2020-finance-audit-committee-meetings/">2020 Finance &amp; Audit Committee Meetings</a><li class="page_item page-item-12857"><a href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/2019-finance-audit-committee-meetings/">2019 Finance &amp; Audit Committee Meetings</a><li class="page_item page-item-12893"><a href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/2018-finance-audit-committee-meetings/">2018 Finance &amp; Audit Committee Meetings</a></ul>
+				</div>
+			</div><div class="et_pb_module et_pb_image et_pb_image_0">
+				
+				
+				<span class="et_pb_image_wrap "><img loading="lazy" src="https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb.jpg" alt="Board of directors" title="bod-thumb" height="auto" width="auto" srcset="https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb.jpg 278w, https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb-16x8.jpg 16w" sizes="(max-width: 278px) 100vw, 278px" class="wp-image-1484" data-pagespeed-url-hash="1929351878" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/></span>
+			</div><div class="et_pb_module et_pb_code et_pb_code_0">
+				
+				
+				<div class="et_pb_code_inner"><div class="dropdown">
+    <button class="btn btn-primary dropdown-toggle btn-block" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Finance & Audit Committee Archives
+    </button>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <a class="dropdown-item" href="/about/board-of-directors/finance-audit-committee/">2022</a>
+			  <a class="dropdown-item" href="/about/board-of-directors/finance-audit-committee/2021-finance-audit-committee-meetings/">2021</a>
+			  <a class="dropdown-item" href="/about/board-of-directors/finance-audit-committee/2020-finance-audit-committee-meetings/">2020</a>
+        <a class="dropdown-item" href="/about/board-of-directors/finance-audit-committee/2019-finance-audit-committee-meetings/">2019</a>
+        <a class="dropdown-item" href="/about/board-of-directors/finance-audit-committee/2018-finance-audit-committee-meetings/">2018</a>
+    </div>
+</div></div>
+			</div> <!-- .et_pb_code --><div class="et_pb_module et_pb_code et_pb_code_1">
+				
+				
+				<div class="et_pb_code_inner"><div class="dropdown">
+    <button class="btn btn-primary dropdown-toggle btn-block" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+        Board Meeting Materials
+    </button>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/">2022</a>
+			  <a class="dropdown-item" href="/about/board-of-directors/schedule/2021-minutes">2021</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2020-minutes">2020</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2019-minutes">2019</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2018-minutes">2018</a>
+    </div>
+</div></div>
+			</div> <!-- .et_pb_code --><div class="et_pb_module et_pb_text et_pb_text_1  et_pb_text_align_left et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><h2>Board Resolutions</h2>
+<p><a href="/about/board-of-directors/board-resolutions/">View the Board Resolutions</a></p>
+<h2>Contact</h2>
+<p>Board of Directors Secretary<br/>(916) 324-1541<br/><a href="mailto:boardmembers@hsr.ca.gov">boardmembers@hsr.ca.gov</a></p>
+</div>
+			</div> <!-- .et_pb_text -->
+			</div> <!-- .et_pb_column -->
+				</div> <!-- .et_pb_row -->
+				
+			</div> <!-- .et_pb_section --><div class="et_pb_section et_pb_section_2 section-primary et_pb_with_background et_section_regular">
+				
+				
+				
+				
+					<div class="et_pb_row et_pb_row_0">
+				<div class="et_pb_column et_pb_column_4_4 et_pb_column_2  et_pb_css_mix_blend_mode_passthrough et-last-child">
+				
+				
+				<div class="et_pb_module et_pb_text et_pb_text_2  et_pb_text_align_center et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><ul class="list-inline">
+<li><a class="btn btn-secondary" href="https://registertovote.ca.gov/">Register to Vote</a></li>
+<li><a class="btn btn-secondary" href="https://www.dmv.ca.gov/portal/dmv/detail/realid">REAL ID</a></li>
+<li><a class="btn btn-secondary" href="https://www.cdph.ca.gov/covid19">COVID-19 Updates</a></li>
+<li><a class="btn btn-secondary" href="https://covid19.ca.gov/vaccines/">Vaccinate All 58</a></li>
+</ul></div>
+			</div> <!-- .et_pb_text --><div class="et_pb_module et_pb_text et_pb_text_3  et_pb_text_align_center et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><p>The California High-Speed Rail Authority makes every effort to ensure the website and its contents meet mandated ADA requirements as per the California State mandated Web Content Accessibility Guidelines 2.0 Level AA standard. If you are looking for a particular document not located on the California High-Speed Rail Authority website, you may make a request for the document under the Public Records Act through the Public Records Act page. If you have any questions about the website or its contents, please contact the Authority at <a href="mailto:info@hsr.ca.gov">info@hsr.ca.gov</a>.</p></div>
+			</div> <!-- .et_pb_text -->
+			</div> <!-- .et_pb_column -->
+				
+				
+			</div> <!-- .et_pb_row -->
+				
+				
+			</div> <!-- .et_pb_section -->		</div><!-- .et_builder_inner_content -->
+	</div><!-- .et-l -->
+	
+			
+		</div><!-- #et-boc -->
+		</div>
+					</article> <!-- .et_pb_post -->
+
+										<span class="return-top hidden-print"></span>
+				</main>
+			</div> <!-- #main-content -->
+		</div>
+	</div>
+	<footer id="footer" class="global-footer hidden-print"><div class="container footer-menu"><div class="group"><div class="three-quarters"><ul class="footer-links"><li><a href="#skip-to-content">Back to Top</a></li><li class="" title=""><a href="/conditions-of-use/">Conditions of Use</a></li><li class="" title=""><a href="/privacy-policy/">Privacy Policy</a></li><li class="" title=""><a href="/accessibility/">Accessibility</a></li><li class="" title=""><a href="/contact/">Contact Us</a></li><li class="" title=""><a href="/a-to-z-index/">A to Z Index</a></li></ul></div><div class="quarter"><ul class="socialsharer-container"><li><a href="https://www.facebook.com/CaliforniaHighSpeedRail/" title="Share via Facebook" target="_blank"><span class="ca-gov-icon-facebook"></span><span class="sr-only">facebook</span></a></li><li><a href="https://twitter.com/cahsra" title="Share via Twitter" target="_blank"><span class="ca-gov-icon-twitter"></span><span class="sr-only">twitter</span></a></li><li><a href="https://www.flickr.com/photos/hsrcagov/" title="Share via Flickr" target="_blank"><span class="ca-gov-icon-flickr"></span><span class="sr-only">flickr</span></a></li><li><a href="https://www.youtube.com/CAHighSpeedRail" title="Share via YouTube" target="_blank"><span class="ca-gov-icon-youtube"></span><span class="sr-only">youtube</span></a></li><li><a href="https://www.instagram.com/cahsra/" title="Share via Instagram" target="_blank"><span class="ca-gov-icon-instagram"></span><span class="sr-only">instagram</span></a></li><li><a href="https://www.linkedin.com/company/california-high-speed-rail-authority" title="Share via LinkedIn" target="_blank"><span class="ca-gov-icon-linkedin"></span><span class="sr-only">linkedin</span></a></li></ul></div></div></div><!-- Copyright Statement --><div class="copyright"><div class="container"><p class="d-inline">Copyright &copy; 2022 State of California</p></div></div></footer>        <div id="trp-floater-ls" onclick="" data-no-translation class="trp-language-switcher-container trp-floater-ls-names trp-bottom-right trp-color-dark">
+            <div id="trp-floater-ls-current-language" class="trp-with-flags">
+                <a href="#" class="trp-floater-ls-disabled-language trp-ls-disabled-language" onclick="event.preventDefault()">
+					<img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/en_US.png" width="18" height="12" alt="en_US" title="English" data-pagespeed-url-hash="2115649056" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">English				</a>
+            </div>
+            <div id="trp-floater-ls-language-list" class="trp-with-flags">
+                <div class="trp-language-wrap">                    <a href="https://hsr.ca.gov/es/about/board-of-directors/finance-audit-committee/" title="Español de México">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/es_MX.png" width="18" height="12" alt="es_MX" title="Español de México" data-pagespeed-url-hash="1320759892" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Español de México					          </a>
+                                    <a href="https://hsr.ca.gov/ar/about/board-of-directors/finance-audit-committee/" title="العربية">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ar.png" width="18" height="12" alt="ar" title="العربية" data-pagespeed-url-hash="2956364983" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">العربية					          </a>
+                                    <a href="https://hsr.ca.gov/hy/about/board-of-directors/finance-audit-committee/" title="Հայերեն">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/hy.png" width="18" height="12" alt="hy" title="Հայերեն" data-pagespeed-url-hash="196385043" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Հայերեն					          </a>
+                                    <a href="https://hsr.ca.gov/hmn/about/board-of-directors/finance-audit-committee/" title="Hmong">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/uploads/2021/05/hmong-16x10.png" width="18" height="12" alt="hmn" title="Hmong" data-pagespeed-url-hash="652958787" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Hmong					          </a>
+                                    <a href="https://hsr.ca.gov/zh/about/board-of-directors/finance-audit-committee/" title="繁體中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_TW.png" width="18" height="12" alt="zh_TW" title="繁體中文" data-pagespeed-url-hash="181731812" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">繁體中文					          </a>
+                                    <a href="https://hsr.ca.gov/zh_hk/about/board-of-directors/finance-audit-committee/" title="香港中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_HK.png" width="18" height="12" alt="zh_HK" title="香港中文" data-pagespeed-url-hash="1845292212" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">香港中文					          </a>
+                                    <a href="https://hsr.ca.gov/zh_cn/about/board-of-directors/finance-audit-committee/" title="简体中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_CN.png" width="18" height="12" alt="zh_CN" title="简体中文" data-pagespeed-url-hash="3104872040" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">简体中文					          </a>
+                                    <a href="https://hsr.ca.gov/ko/about/board-of-directors/finance-audit-committee/" title="한국어">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ko_KR.png" width="18" height="12" alt="ko_KR" title="한국어" data-pagespeed-url-hash="2804872994" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">한국어					          </a>
+                                    <a href="https://hsr.ca.gov/ja/about/board-of-directors/finance-audit-committee/" title="日本語">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ja.png" width="18" height="12" alt="ja" title="日本語" data-pagespeed-url-hash="1567889505" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">日本語					          </a>
+                                    <a href="https://hsr.ca.gov/pa/about/board-of-directors/finance-audit-committee/" title="ਪੰਜਾਬੀ">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/pa_IN.png" width="18" height="12" alt="pa_IN" title="ਪੰਜਾਬੀ" data-pagespeed-url-hash="1605722755" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">ਪੰਜਾਬੀ					          </a>
+                                    <a href="https://hsr.ca.gov/tl/about/board-of-directors/finance-audit-committee/" title="Tagalog">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/tl.png" width="18" height="12" alt="tl" title="Tagalog" data-pagespeed-url-hash="4055228506" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Tagalog					          </a>
+                                    <a href="https://hsr.ca.gov/vi/about/board-of-directors/finance-audit-committee/" title="Tiếng Việt">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/vi.png" width="18" height="12" alt="vi" title="Tiếng Việt" data-pagespeed-url-hash="3021296717" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Tiếng Việt					          </a>
+                <a href="#" class="trp-floater-ls-disabled-language trp-ls-disabled-language" onclick="event.preventDefault()"><img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/en_US.png" width="18" height="12" alt="en_US" title="English" data-pagespeed-url-hash="2115649056" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">English</a></div>            </div>
+        </div>
+
+    			<script>document.body.classList.remove('primary');</script>
+		<script>var $=jQuery;</script>
+
+<script src="/wp-content/custom/js/library.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.4.6/js/swiper.min.js"></script>
+<script>var swiper=new Swiper('.swiper-container',{slidesPerView:4,spaceBetween:2,loop:true,navigation:{nextEl:'.section__gallery-button--next',prevEl:'.section__gallery-button--prev',},breakpoints:{1440:{slidesPerView:3},900:{slidesPerView:2},550:{slidesPerView:1}}});</script>
+
+<script>document.addEventListener("DOMContentLoaded",function(event){document.querySelectorAll('.info-image__popup')});</script>
+
+<script type='text/javascript' id='thickbox-js-extra'>//<![CDATA[
+var thickboxL10n={"next":"Next >","prev":"< Prev","image":"Image","of":"of","close":"Close","noiframes":"This feature requires inline frames. You have iframes disabled or your browser does not support them.","loadingAnimation":"https:\/\/hsr.ca.gov\/wp-includes\/js\/thickbox\/loadingAnimation.gif"};
+//]]></script>
+<script type='text/javascript' defer src='https://hsr.ca.gov/wp-includes/js/thickbox/thickbox.js?ver=3.1-20121105' id='thickbox-js'></script>
+<script type='text/javascript' id='et-builder-modules-global-functions-script-js-extra'>//<![CDATA[
+var et_builder_utils_params={"condition":{"diviTheme":true,"extraTheme":false},"scrollLocations":["app","top"],"builderScrollLocations":{"desktop":"app","tablet":"app","phone":"app"},"onloadScrollLocation":"app","builderType":"fe"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/frontend-builder/build/frontend-builder-global-functions.js?ver=4.9.3' id='et-builder-modules-global-functions-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.mobile.custom.min.js?ver=4.9.3' id='et-jquery-touch-mobile-js'></script>
+<script type='text/javascript' id='divi-custom-script-js-extra'>//<![CDATA[
+var DIVI={"item_count":"%d Item","items_count":"%d Items"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/js/custom.js?ver=4.9.3' id='divi-custom-script-js'></script>
+<script type='text/javascript' id='et-builder-modules-script-js-extra'>//<![CDATA[
+var et_frontend_scripts={"builderCssContainerPrefix":"#et-boc","builderCssLayoutPrefix":"#et-boc .et-l"};var et_pb_custom={"ajaxurl":"https:\/\/hsr.ca.gov\/wp-admin\/admin-ajax.php","images_uri":"https:\/\/hsr.ca.gov\/wp-content\/themes\/Divi\/images","builder_images_uri":"https:\/\/hsr.ca.gov\/wp-content\/themes\/Divi\/includes\/builder\/images","et_frontend_nonce":"f62cb714dd","subscription_failed":"Please, check the fields below to make sure you entered the correct information.","et_ab_log_nonce":"be7854d387","fill_message":"Please, fill in the following fields:","contact_error_message":"Please, fix the following errors:","invalid":"Invalid email","captcha":"Captcha","prev":"Prev","previous":"Previous","next":"Next","wrong_captcha":"You entered the wrong number in captcha.","wrong_checkbox":"Checkbox","ignore_waypoints":"no","is_divi_theme_used":"1","widget_search_selector":".widget_search","ab_tests":[],"is_ab_testing_active":"","page_id":"9600","unique_test_id":"","ab_bounce_rate":"5","is_cache_plugin_active":"no","is_shortcode_tracking":"","tinymce_uri":""};var et_pb_box_shadow_elements=[];var et_pb_motion_elements={"desktop":[],"tablet":[],"phone":[]};var et_pb_sticky_elements=[];
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/frontend-builder/build/frontend-builder-scripts.js?ver=4.9.3' id='et-builder-modules-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/plugins/hsr-plugins/scripts/frontend-bundle.min.js?ver=1.0.0' id='symsoft-divi-extension-frontend-bundle-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/divi/extension/scripts/frontend-bundle.min.js?ver=1.0.0' id='caweb-module-extension-frontend-bundle-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.fitvids.js?ver=4.9.3' id='divi-fitvids-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/waypoints.min.js?ver=4.9.3' id='waypoints-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.magnific-popup.js?ver=4.9.3' id='magnific-popup-js'></script>
+<script type='text/javascript' id='cagov-caweb-script-js-extra'>//<![CDATA[
+var args={"ca_google_analytic_id":"UA-73985215-2","ca_google_tag_manager_id":"GTM-N6J3M4W","ca_google_tag_manager_approved":"","ca_site_version":"5","ca_frontpage_search_enabled":"","ca_google_search_id":"001779225245372747843:jso5c-pvxls","caweb_multi_ga":"","ca_google_trans_enabled":"","ajaxurl":"https:\/\/hsr.ca.gov\/wp-admin\/admin-post.php"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/js/caweb-v5.min.js?ver=5.7.7' id='cagov-caweb-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/core/admin/js/common.js?ver=4.9.3' id='et-core-common-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/caweb-1.5.0-ext/js/1/caweb-custom.js?ver=-6340b2c487e455.80488597' id='caweb-custom-js-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/wp-embed.js?ver=5.7.7' id='wp-embed-js'></script>
+<style id="et-builder-module-design-9600-cached-inline-styles">.et_pb_section_0.et_pb_section{padding-top:0;margin-top:0}.et_pb_column_1{padding-top:0}.et_pb_column_0{padding-top:0}.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7}.{max-width:none}.et_pb_toggle_8.et_pb_toggle h5,.et_pb_toggle_8.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_4.et_pb_toggle h5,.et_pb_toggle_4.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_5.et_pb_toggle h5,.et_pb_toggle_5.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_1.et_pb_toggle h5,.et_pb_toggle_1.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_2.et_pb_toggle h5,.et_pb_toggle_2.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_3.et_pb_toggle h5,.et_pb_toggle_3.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_6.et_pb_toggle h5,.et_pb_toggle_6.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_7.et_pb_toggle h5,.et_pb_toggle_7.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_0.et_pb_toggle h5,.et_pb_toggle_0.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_module.et_pb_toggle_6.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_7.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_8.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_toggle_2.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_8.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_4.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_5.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_7.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_0.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_6.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_3.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_1.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_7.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_6.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_8.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_8 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_4 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_7 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_6 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_5 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_3 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_2 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_1 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_0 .et_pb_toggle_title:before{color:#007fad}.et_pb_divider_0{background-color:#007fad;padding-top:7rem;margin-bottom:0!important}.et_pb_divider_0:before{border-top-color:#007fad;width:auto;top:7rem;right:0;left:0}.et_pb_ca_siblingPages_0{background-color:#007fad;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem;margin-bottom:0!important}.et_pb_image_0{margin-top:0!important;width:100%;max-width:100%!important;text-align:left;margin-left:0}.et_pb_image_0 .et_pb_image_wrap,.et_pb_image_0 img{width:100%}.et_pb_text_1 h2{font-weight:700;text-transform:uppercase;font-size:20px}.et_pb_section_2.et_pb_section{background-color:#22407d!important}.et_pb_text_3{max-width:630px}.et_pb_text_3.et_pb_module{margin-left:auto!important;margin-right:auto!important}@media only screen and (max-width:980px){.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_6.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_7.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_8.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_divider_0{padding-top:0}.et_pb_divider_0:before{width:auto;top:0;right:0;left:0}}@media only screen and (min-width:768px) and (max-width:980px){.et_pb_ca_breadcrumb_0{display:none!important}}@media only screen and (max-width:767px){.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7;display:none!important}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_6.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_7.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_8.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}}</style>		<script>$=jQuery.noConflict();var media_carousels=$('div[class*="et_pb_ca_fullwidth_section_carousel_"]:not(".item")');media_carousels.each(function(index,carousel){if($(carousel).hasClass('media')||$(carousel).hasClass('panel')){$(carousel).find('.carousel-media').owlCarousel({responsive:true,responsive:{0:{items:1,nav:true},400:{items:1,nav:true},768:{items:undefined===carousel.slide_amount?4:carousel.slide_amount,nav:true},},margin:10,nav:true,dots:false,navText:['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>','<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'],});}})</script>
+				<script>$=jQuery.noConflict();var media_carousels=$('div[class*="et_pb_ca_section_carousel_"]:not(".item")');media_carousels.each(function(index,carousel){if($(carousel).hasClass('media')||$(carousel).hasClass('panel')){$(carousel).find('.carousel-media').owlCarousel({responsive:true,responsive:{0:{items:1,nav:true},400:{items:1,nav:true},768:{items:undefined===carousel.slide_amount?4:carousel.slide_amount,nav:true},},margin:10,nav:true,dots:false,navText:['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>','<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'],});}})</script>
+		</body>
+</html>
+
+<!--
+Performance optimized by W3 Total Cache. Learn more: https://www.boldgrid.com/w3-total-cache/
+
+Page Caching using disk: enhanced 
+
+Served from: hsr.ca.gov @ 2022-10-07 16:14:12 by W3 Total Cache
+-->

--- a/tests/files/ca_highspeed_rail_special_committee.html
+++ b/tests/files/ca_highspeed_rail_special_committee.html
@@ -1,0 +1,524 @@
+
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="Author" content="State of California"/>
+	<meta name="Description" content="State of California"/>
+	<meta name="Keywords" content="California, government"/>
+
+	<!-- http://t.co/dKP3o1e -->
+	<meta name="HandheldFriendly" content="True">
+
+	<!-- for Blackberry, AvantGo -->
+	<meta name="MobileOptimized" content="320">
+
+	<!-- for Windows mobile -->
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+	<!-- Google Meta-->
+	<meta name="google-site-verification" content="001779225245372747843:jso5c-pvxls"/>
+
+	
+	
+	<link rel="apple-touch-icon-precomposed" sizes="100x100" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-precomposed.png">
+	<link rel="apple-touch-icon-precomposed" sizes="192x192" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-192x192.png">
+	<link rel="apple-touch-icon-precomposed" sizes="180x180" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-180x180.png">
+	<link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-152x152.png">
+	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-144x144.png">
+	<link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-120x120.png">
+	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-114x114.png">
+	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon-precomposed" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon-57x57.png">
+	<link rel="apple-touch-icon" href="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/apple-touch-icon.png">
+
+
+	<script>var et_site_url='https://hsr.ca.gov';var et_post_id='15821';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}</script><title>Special Matters Committee &#x2d; California High Speed Rail</title>
+<meta name='robots' content='max-image-preview:large'/>
+
+<!-- The SEO Framework by Sybre Waaijer -->
+<meta name="robots" content="max-snippet:-1,max-image-preview:standard,max-video-preview:-1"/>
+<meta property="og:locale" content="en_US"/>
+<meta property="og:type" content="website"/>
+<meta property="og:title" content="Special Matters Committee &#x2d; California High Speed Rail"/>
+<meta property="og:url" content="https://hsr.ca.gov/about/board-of-directors/special-matters-committee/"/>
+<meta property="og:site_name" content="California High Speed Rail"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Special Matters Committee &#x2d; California High Speed Rail"/>
+<link rel="canonical" href="https://hsr.ca.gov/about/board-of-directors/special-matters-committee/"/>
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item": {
+                "@id": "https://hsr.ca.gov/",
+                "name": "California High Speed Rail"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/",
+                "name": "About"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/board-of-directors/",
+                "name": "Board of Directors"
+            }
+        },
+        {
+            "@type": "ListItem",
+            "position": 4,
+            "item": {
+                "@id": "https://hsr.ca.gov/about/board-of-directors/special-matters-committee/",
+                "name": "Special Matters Committee"
+            }
+        }
+    ]
+}</script>
+<!-- / The SEO Framework by Sybre Waaijer | 11.69ms meta | 0.59ms boot -->
+
+<link rel='dns-prefetch' href='//fonts.googleapis.com'/>
+<link rel='dns-prefetch' href='//s.w.org'/>
+<link rel="alternate" type="application/rss+xml" title="California High Speed Rail &raquo; Feed" href="https://hsr.ca.gov/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="California High Speed Rail &raquo; Comments Feed" href="https://hsr.ca.gov/comments/feed/"/>
+		<script type="text/javascript">window._wpemojiSettings={"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/svg\/","svgExt":".svg","source":{"wpemoji":"https:\/\/hsr.ca.gov\/wp-includes\/js\/wp-emoji.js?ver=5.7.7","twemoji":"https:\/\/hsr.ca.gov\/wp-includes\/js\/twemoji.js?ver=5.7.7"}};(function(window,document,settings){var src,ready,ii,tests;var canvas=document.createElement('canvas');var context=canvas.getContext&&canvas.getContext('2d');function emojiSetsRenderIdentically(set1,set2){var stringFromCharCode=String.fromCharCode;context.clearRect(0,0,canvas.width,canvas.height);context.fillText(stringFromCharCode.apply(this,set1),0,0);var rendered1=canvas.toDataURL();context.clearRect(0,0,canvas.width,canvas.height);context.fillText(stringFromCharCode.apply(this,set2),0,0);var rendered2=canvas.toDataURL();return rendered1===rendered2;}function browserSupportsEmoji(type){var isIdentical;if(!context||!context.fillText){return false;}context.textBaseline='top';context.font='600 32px Arial';switch(type){case'flag':isIdentical=emojiSetsRenderIdentically([0x1F3F3,0xFE0F,0x200D,0x26A7,0xFE0F],[0x1F3F3,0xFE0F,0x200B,0x26A7,0xFE0F]);if(isIdentical){return false;}isIdentical=emojiSetsRenderIdentically([0xD83C,0xDDFA,0xD83C,0xDDF3],[0xD83C,0xDDFA,0x200B,0xD83C,0xDDF3]);if(isIdentical){return false;}isIdentical=emojiSetsRenderIdentically([0xD83C,0xDFF4,0xDB40,0xDC67,0xDB40,0xDC62,0xDB40,0xDC65,0xDB40,0xDC6E,0xDB40,0xDC67,0xDB40,0xDC7F],[0xD83C,0xDFF4,0x200B,0xDB40,0xDC67,0x200B,0xDB40,0xDC62,0x200B,0xDB40,0xDC65,0x200B,0xDB40,0xDC6E,0x200B,0xDB40,0xDC67,0x200B,0xDB40,0xDC7F]);return!isIdentical;case'emoji':isIdentical=emojiSetsRenderIdentically([0xD83D,0xDC68,0x200D,0xD83C,0xDF7C],[0xD83D,0xDC68,0x200B,0xD83C,0xDF7C]);return!isIdentical;}return false;}function addScript(src){var script=document.createElement('script');script.src=src;script.defer=script.type='text/javascript';document.getElementsByTagName('head')[0].appendChild(script);}tests=Array('flag','emoji');settings.supports={everything:true,everythingExceptFlag:true};for(ii=0;ii<tests.length;ii++){settings.supports[tests[ii]]=browserSupportsEmoji(tests[ii]);settings.supports.everything=settings.supports.everything&&settings.supports[tests[ii]];if('flag'!==tests[ii]){settings.supports.everythingExceptFlag=settings.supports.everythingExceptFlag&&settings.supports[tests[ii]];}}settings.supports.everythingExceptFlag=settings.supports.everythingExceptFlag&&!settings.supports.flag;settings.DOMReady=false;settings.readyCallback=function(){settings.DOMReady=true;};if(!settings.supports.everything){ready=function(){settings.readyCallback();};if(document.addEventListener){document.addEventListener('DOMContentLoaded',ready,false);window.addEventListener('load',ready,false);}else{window.attachEvent('onload',ready);document.attachEvent('onreadystatechange',function(){if('complete'===document.readyState){settings.readyCallback();}});}src=settings.source||{};if(src.concatemoji){addScript(src.concatemoji);}else if(src.wpemoji&&src.twemoji){addScript(src.twemoji);addScript(src.wpemoji);}}})(window,document,window._wpemojiSettings);</script>
+		<meta content="CAWeb v.1.5.0" name="generator"/><style type="text/css">img.wp-smiley,img.emoji{display:inline!important;border:none!important;box-shadow:none!important;height:1em!important;width:1em!important;margin:0 .07em!important;vertical-align:-.1em!important;background:none!important;padding:0!important}</style>
+	<link rel='stylesheet' id='dashicons-css' href='https://hsr.ca.gov/wp-includes/css/dashicons.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='thickbox-css' href='https://hsr.ca.gov/wp-includes/js/thickbox/thickbox.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='wp-block-library-css' href='https://hsr.ca.gov/wp-includes/css/dist/block-library/style.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='trp-floater-language-switcher-style-css' href='https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/css/trp-floater-language-switcher.css?ver=2.0.1' type='text/css' media='all'/>
+<link rel='stylesheet' id='trp-language-switcher-style-css' href='https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/css/trp-language-switcher.css?ver=2.0.1' type='text/css' media='all'/>
+<link rel='stylesheet' id='parent-style-css' href='https://hsr.ca.gov/wp-content/themes/Divi/style.dev.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='divi-style-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/style.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='symsoft-divi-extension-styles-css' href='https://hsr.ca.gov/wp-content/plugins/hsr-plugins/styles/style.min.css?ver=1.0.0' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-module-extension-styles-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/divi/extension/styles/style.min.css?ver=1.0.0' type='text/css' media='all'/>
+<link rel='stylesheet' id='et-builder-googlefonts-cached-css' href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200italic,300,300italic,regular,italic,600,600italic,700,700italic,900,900italic&#038;subset=latin,latin-ext&#038;display=swap' type='text/css' media='all'/>
+<link rel='stylesheet' id='tablepress-default-css' href='https://hsr.ca.gov/wp-content/plugins/tablepress/css/default.css?ver=1.13' type='text/css' media='all'/>
+<link rel='stylesheet' id='tablepress-responsive-tables-css' href='https://hsr.ca.gov/wp-content/plugins/tablepress-responsive-tables/css/tablepress-responsive.css?ver=1.8' type='text/css' media='all'/>
+<link rel='stylesheet' id='et-shortcodes-responsive-css-css' href='https://hsr.ca.gov/wp-content/themes/Divi/epanel/shortcodes/css/shortcodes_responsive.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='magnific-popup-css' href='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/styles/magnific_popup.css?ver=4.9.3' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-core-style-css' href='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/css/cagov-v5-oceanside.min.css?ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='cagov-google-font-style-css' href='https://fonts.googleapis.com/css?family=Asap+Condensed%3A400%2C600%7CSource+Sans+Pro%3A400%2C700&#038;ver=5.7.7' type='text/css' media='all'/>
+<link rel='stylesheet' id='caweb-custom-css-styles-css' href='https://hsr.ca.gov/wp-content/caweb-1.5.0-ext/css/1/caweb-custom.css?ver=-6340c141d96699.04220580' type='text/css' media='all'/>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/jquery/jquery.js?ver=3.5.1' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/jquery/jquery-migrate.js?ver=3.3.2' id='jquery-migrate-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/plugins/wpo365-login/apps/dist/pintra-redirect.js?ver=12.11' id='pintraredirectjs-js'></script>
+<script type='text/javascript' defer src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/js/libs/modernizr-3.6.0.min.js?ver=5.7.7' id='cagov-modernizr-script-js'></script>
+<link rel="https://api.w.org/" href="https://hsr.ca.gov/wp-json/"/><link rel="alternate" type="application/json" href="https://hsr.ca.gov/wp-json/wp/v2/pages/15821"/><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://hsr.ca.gov/xmlrpc.php?rsd"/>
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://hsr.ca.gov/wp-includes/wlwmanifest.xml"/> 
+<link rel="alternate" type="application/json+oembed" href="https://hsr.ca.gov/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fhsr.ca.gov%2Fabout%2Fboard-of-directors%2Fspecial-matters-committee%2F"/>
+<link rel="alternate" type="text/xml+oembed" href="https://hsr.ca.gov/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fhsr.ca.gov%2Fabout%2Fboard-of-directors%2Fspecial-matters-committee%2F&#038;format=xml"/>
+<link rel="alternate" hreflang="en-US" href="https://hsr.ca.gov/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="en" href="https://hsr.ca.gov/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="es-MX" href="https://hsr.ca.gov/es/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="es" href="https://hsr.ca.gov/es/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="ar" href="https://hsr.ca.gov/ar/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="hy" href="https://hsr.ca.gov/hy/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="hmn" href="https://hsr.ca.gov/hmn/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="zh-TW" href="https://hsr.ca.gov/zh/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="zh" href="https://hsr.ca.gov/zh/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="zh-HK" href="https://hsr.ca.gov/zh_hk/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="zh-CN" href="https://hsr.ca.gov/zh_cn/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="ko-KR" href="https://hsr.ca.gov/ko/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="ko" href="https://hsr.ca.gov/ko/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="ja" href="https://hsr.ca.gov/ja/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="pa-IN" href="https://hsr.ca.gov/pa/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="pa" href="https://hsr.ca.gov/pa/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="tl" href="https://hsr.ca.gov/tl/about/board-of-directors/special-matters-committee/"/>
+<link rel="alternate" hreflang="vi" href="https://hsr.ca.gov/vi/about/board-of-directors/special-matters-committee/"/>
+<script>(function($){$(window).bind("load",function(){$('.fluid-width-video-wrapper').each(function(){var src=$(this).find('iframe').attr('src');$(this).find('iframe').attr('src',src+'&amp;rel=0');});});})(jQuery)</script>
+
+<link title="Fav Icon" rel="icon" href="https://hsr.ca.gov/wp-content/uploads/2020/12/favicon.ico">
+<link rel="shortcut icon" href="https://hsr.ca.gov/wp-content/uploads/2020/12/favicon.ico">
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/><link rel="preload" href="https://hsr.ca.gov/wp-content/themes/Divi/core/admin/fonts/modules.ttf" as="font" crossorigin="anonymous"><link rel="shortcut icon" href=""/><style type="text/css">.broken_link,a.broken_link{text-decoration:line-through}</style><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.4.6/css/swiper.min.css"><link rel="stylesheet" id="et-divi-customizer-global-cached-inline-styles" href="https://hsr.ca.gov/wp-content/et-cache/1/1/global/et-divi-customizer-global-16595570436405.min.css" onerror="et_core_page_resource_fallback(this, true)" onload="et_core_page_resource_fallback(this)"/>
+
+</head>
+<body class="page-template-default page page-id-15821 page-child parent-pageid-1126 primary translatepress-en_US et_pb_button_helper_class et_header_style_left et_pb_footer_columns4 et_cover_background et_pb_gutter osx et_pb_gutters3 et_pb_pagebuilder_layout et_no_sidebar et_divi_theme et-db divi_builder title_not_displayed v5 sidebar_not_displayed ">
+	<!-- Google Tag Manager (noscript) -->
+<noscript>
+	<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6J3M4W" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+			
+
+<header id="header" class="global-header">
+	<div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+	<!-- Alert Banners -->
+<!-- Utility Header -->
+<div class="utility-header hidden-print">
+	<div class="container">
+		<div class="group flex-row">
+			<div class="social-media-links">
+				<div class="header-cagov-logo">
+					<a href="https://www.ca.gov/" title="CA.gov website">
+						<span class="sr-only">CA.gov</span>
+						<script data-pagespeed-no-defer>//<![CDATA[
+(function(){for(var g="function"==typeof Object.defineProperties?Object.defineProperty:function(b,c,a){if(a.get||a.set)throw new TypeError("ES3 does not support getters and setters.");b!=Array.prototype&&b!=Object.prototype&&(b[c]=a.value)},h="undefined"!=typeof window&&window===this?this:"undefined"!=typeof global&&null!=global?global:this,k=["String","prototype","repeat"],l=0;l<k.length-1;l++){var m=k[l];m in h||(h[m]={});h=h[m]}var n=k[k.length-1],p=h[n],q=p?p:function(b){var c;if(null==this)throw new TypeError("The 'this' value for String.prototype.repeat must not be null or undefined");c=this+"";if(0>b||1342177279<b)throw new RangeError("Invalid count value");b|=0;for(var a="";b;)if(b&1&&(a+=c),b>>>=1)c+=c;return a};q!=p&&null!=q&&g(h,n,{configurable:!0,writable:!0,value:q});var t=this;function u(b,c){var a=b.split("."),d=t;a[0]in d||!d.execScript||d.execScript("var "+a[0]);for(var e;a.length&&(e=a.shift());)a.length||void 0===c?d[e]?d=d[e]:d=d[e]={}:d[e]=c};function v(b){var c=b.length;if(0<c){for(var a=Array(c),d=0;d<c;d++)a[d]=b[d];return a}return[]};function w(b){var c=window;if(c.addEventListener)c.addEventListener("load",b,!1);else if(c.attachEvent)c.attachEvent("onload",b);else{var a=c.onload;c.onload=function(){b.call(this);a&&a.call(this)}}};var x;function y(b,c,a,d,e){this.h=b;this.j=c;this.l=a;this.f=e;this.g={height:window.innerHeight||document.documentElement.clientHeight||document.body.clientHeight,width:window.innerWidth||document.documentElement.clientWidth||document.body.clientWidth};this.i=d;this.b={};this.a=[];this.c={}}function z(b,c){var a,d,e=c.getAttribute("data-pagespeed-url-hash");if(a=e&&!(e in b.c))if(0>=c.offsetWidth&&0>=c.offsetHeight)a=!1;else{d=c.getBoundingClientRect();var f=document.body;a=d.top+("pageYOffset"in window?window.pageYOffset:(document.documentElement||f.parentNode||f).scrollTop);d=d.left+("pageXOffset"in window?window.pageXOffset:(document.documentElement||f.parentNode||f).scrollLeft);f=a.toString()+","+d;b.b.hasOwnProperty(f)?a=!1:(b.b[f]=!0,a=a<=b.g.height&&d<=b.g.width)}a&&(b.a.push(e),b.c[e]=!0)}y.prototype.checkImageForCriticality=function(b){b.getBoundingClientRect&&z(this,b)};u("pagespeed.CriticalImages.checkImageForCriticality",function(b){x.checkImageForCriticality(b)});u("pagespeed.CriticalImages.checkCriticalImages",function(){A(x)});function A(b){b.b={};for(var c=["IMG","INPUT"],a=[],d=0;d<c.length;++d)a=a.concat(v(document.getElementsByTagName(c[d])));if(a.length&&a[0].getBoundingClientRect){for(d=0;c=a[d];++d)z(b,c);a="oh="+b.l;b.f&&(a+="&n="+b.f);if(c=!!b.a.length)for(a+="&ci="+encodeURIComponent(b.a[0]),d=1;d<b.a.length;++d){var e=","+encodeURIComponent(b.a[d]);131072>=a.length+e.length&&(a+=e)}b.i&&(e="&rd="+encodeURIComponent(JSON.stringify(B())),131072>=a.length+e.length&&(a+=e),c=!0);C=a;if(c){d=b.h;b=b.j;var f;if(window.XMLHttpRequest)f=new XMLHttpRequest;else if(window.ActiveXObject)try{f=new ActiveXObject("Msxml2.XMLHTTP")}catch(r){try{f=new ActiveXObject("Microsoft.XMLHTTP")}catch(D){}}f&&(f.open("POST",d+(-1==d.indexOf("?")?"?":"&")+"url="+encodeURIComponent(b)),f.setRequestHeader("Content-Type","application/x-www-form-urlencoded"),f.send(a))}}}function B(){var b={},c;c=document.getElementsByTagName("IMG");if(!c.length)return{};var a=c[0];if(!("naturalWidth"in a&&"naturalHeight"in a))return{};for(var d=0;a=c[d];++d){var e=a.getAttribute("data-pagespeed-url-hash");e&&(!(e in b)&&0<a.width&&0<a.height&&0<a.naturalWidth&&0<a.naturalHeight||e in b&&a.width>=b[e].o&&a.height>=b[e].m)&&(b[e]={rw:a.width,rh:a.height,ow:a.naturalWidth,oh:a.naturalHeight})}return b}var C="";u("pagespeed.CriticalImages.getBeaconData",function(){return C});u("pagespeed.CriticalImages.Run",function(b,c,a,d,e,f){var r=new y(b,c,a,e,f);x=r;d&&w(function(){window.setTimeout(function(){A(r)},0)})});})();pagespeed.CriticalImages.Run('/mod_pagespeed_beacon','https://hsr.ca.gov/about/board-of-directors/special-matters-committee/','8Xxa2XQLv9',true,false,'t3loOKj__ZU');
+//]]></script><img style="height: 31px;" src="https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/images/system/logo.svg" class="pos-rel" alt="CA.gov website" aria-hidden="true" data-pagespeed-url-hash="3038728008" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/>
+					</a>
+				</div>
+
+									<a href="/" title="Home" class="utility-home-icon ca-gov-icon-home"><span class="sr-only">Home</span></a>
+											<a class="utility-social-facebook ca-gov-icon-facebook" href="https://www.facebook.com/CaliforniaHighSpeedRail/" title="Share via Facebook" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Facebook</span>
+						</a>
+												<a class="utility-social-twitter ca-gov-icon-twitter" href="https://twitter.com/cahsra" title="Share via Twitter" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Twitter</span>
+						</a>
+												<a class="utility-social-flickr ca-gov-icon-flickr" href="https://www.flickr.com/photos/hsrcagov/" title="Share via Flickr" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Flickr</span>
+						</a>
+												<a class="utility-social-youtube ca-gov-icon-youtube" href="https://www.youtube.com/CAHighSpeedRail" title="Share via YouTube" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via YouTube</span>
+						</a>
+												<a class="utility-social-instagram ca-gov-icon-instagram" href="https://www.instagram.com/cahsra/" title="Share via Instagram" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via Instagram</span>
+						</a>
+												<a class="utility-social-linkedin ca-gov-icon-linkedin" href="https://www.linkedin.com/company/california-high-speed-rail-authority" title="Share via LinkedIn" target=&quot;_blank&quot;>
+							<span class="sr-only">Share via LinkedIn</span>
+						</a>
+									</div>
+			<div class="settings-links">
+				<a class="utility-custom-1" href="/wp-content/uploads/docs/about/SIMM_25B_Web_Accessibility_Cert.pdf">ADA Certification</a><a class="utility-custom-2" href="/a-to-z-index/">A to Z Index</a>								<a class="utility-contact-us" href="/contact/">Contact Us</a>
+				
+												<button class="btn btn-xs btn-primary collapsed" data-toggle="collapse" data-target="#siteSettings" aria-controls="siteSettings">
+					<span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="site-settings section section-standout collapse collapsed" aria-atomic="true" role="alert" id="siteSettings">
+	<div class="container  p-y">
+		<div class="btn-group btn-group-justified-sm" role="group" aria-label="contrastMode">
+			<div class="btn-group"><button type="button" class="btn btn-standout disableHighContrastMode">Default</button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High Contrast</button></div>
+		</div>
+
+		<div class="btn-group" role="group" aria-label="textSizeMode">
+			<div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <span class="sr-only">Increase</span><span class="ca-gov-icon-plus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+			<div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <span class="sr-only">Decrease</span><span class="ca-gov-icon-minus-line font-size-sm" aria-hidden="true"></span></span></button></div>
+		</div>
+		<button type="button" class="close" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+	</div>
+</div>
+<!-- Branding -->
+<div class="branding">
+	<div class="header-organization-banner">
+		<a href="/">
+			<img src="https://hsr.ca.gov/wp-content/uploads/2021/05/HSR_Logo_80px_height.png" alt="CA High-Speed Rail Authority Logo" data-pagespeed-url-hash="62514589" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/>
+		</a>
+	</div>
+</div>
+<!-- mobile navigation controls -->
+<div class="mobile-controls">
+    <span class="mobile-control-group mobile-header-icons">
+        <!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+    <div class="mobile-control-group main-nav-icons">
+                <button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+                <button id="nav-icon3" class="mobile-control toggle-menu" aria-expanded="false" aria-controls="navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+
+    </div>
+</div>
+
+	<div class="navigation-search">
+
+		<!-- Version 4 top-right search box always displayed -->
+		<!-- Version 5.0 fade in/out search box displays on front page and if option is enabled -->
+		<!-- Include Navigation -->
+		<nav id="navigation" class="main-navigation singlelevel hidden-print">
+                                <ul id="nav_list" class="top-level-nav"><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor  " title=""><a href="https://hsr.ca.gov/about/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">About</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/programs/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Programs</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/high-speed-rail-in-california/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">High-Speed Rail in California</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/business-opportunities/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Business Opportunities</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/jobs/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Jobs</span></a></li><li class="nav-item  menu-item menu-item-type-post_type menu-item-object-page  " title=""><a href="https://hsr.ca.gov/communications-outreach/" class="first-level-link"><span class="ca-gov-icon-logo invisible"></span><span class="link-title">Communications &amp; Outreach</span></a></li><li class="nav-item" id="nav-item-search"><button class="first-level-link h-auto"><span class="ca-gov-icon-search" aria-hidden="true"></span> Search</button></li></ul></nav>		<div id="head-search" class="search-container hidden-print" role="region" aria-label="Search Expanded">
+			<div class="container">
+	<form id="Search" class="pos-rel" action="https://hsr.ca.gov/serp">
+		<span class="sr-only" id="SearchInput">Custom Google Search</span>
+		<input type="text" id="q" name="q" value="" aria-labelledby="SearchInput" placeholder="Search this website" class="search-textfield height-50 border-0 p-x-sm w-100"/>
+		<button type="submit" class="pos-abs gsc-search-button top-0 width-50 height-50 border-0 bg-transparent">
+			<span class="ca-gov-icon-search font-size-30 color-gray"></span>
+			<span class="sr-only">Submit</span>
+		</button>
+		<div class="width-50 height-50 close-search-btn">
+			<!-- Some Google styles add an 'x' background image when button has 'gsc-clear-button' in the class -->
+			<button class="close-search width-50 height-50 border-0 bg-transparent pos-rel" type="reset">
+				<span class="sr-only">Close Search</span>
+				<span class="ca-gov-icon-close-mark"></span>
+			</button>
+		</div>
+	</form>
+</div>
+		</div>
+	</div>
+</header>
+
+	<div id="page-container">
+		<div id="et-main-area">
+
+			<div id="main-content" class="main-content" tabindex="-1">
+				<main class="main-primary">
+
+					
+					<article id="post-15821" class="post-15821 page type-page status-publish hentry">
+
+						<div class="entry-content"><div id="et-boc" class="et-boc">
+			
+		<div class="et-l et-l--post">
+			<div class="et_builder_inner_content et_pb_gutters3">
+		<div class="et_pb_section et_pb_section_0 et_section_specialty">
+				
+				
+				
+				<div class="et_pb_row">
+					<div class="et_pb_column et_pb_column_2_3 et_pb_column_0   et_pb_specialty_column  et_pb_css_mix_blend_mode_passthrough">
+				
+				
+				<div class="et_pb_row_inner et_pb_row_inner_0">
+				<div class="et_pb_column et_pb_column_4_4 et_pb_column_inner et_pb_column_inner_0 et-last-child">
+				
+				
+				<div class="et_pb_with_border et_pb_module et_pb_ca_breadcrumb et_pb_ca_breadcrumb_0">
+				
+				
+				
+				
+				<div class="et_pb_module_inner">
+					<ol class="breadcrumb"><li><a href="/" title="home">Home</a></li><li><a href="https://hsr.ca.gov/about/" title="About">About</a></li><li><a href="https://hsr.ca.gov/about/board-of-directors/" title="Board of Directors">Board of Directors</a></li><li>Special Matters Committee</li></ol>
+				</div>
+			</div><div class="et_pb_module et_pb_text et_pb_text_0  et_pb_text_align_left et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><h1>Special Matters Committee</h1>
+<p>&nbsp;</p>
+<h2>2021 Special Matters Committee Meetings</h2></div>
+			</div> <!-- .et_pb_text --><div class="et_pb_module et_pb_toggle et_pb_toggle_0 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 29, 2021</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li>March 29, 2021 Special Matters Committee Meeting Agenda (Canceled)</li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_1 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 22, 2021</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2021/04/brdmtg_032221_SM_Committee_Agenda.pdf">March 22, 2021 Special Matters Committee Meeting Agenda</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_2 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 15, 2021</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2021/03/brdmtg_031521_SM_Committee_Agenda.pdf">March 15, 2021 Special Matters Committee Meeting Agenda</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_3 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 8, 2021</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2021/03/brdmtg_030821_SM_Committee_Agenda.pdf">March 8, 2021 Special Matters Committee Meeting Agenda</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_4 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">March 1, 2021</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2021/03/brdmtg_030121_SM_Committee_Agenda.pdf">March 1, 2021 Special Matters Committee Meeting Agenda</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle --><div class="et_pb_module et_pb_toggle et_pb_toggle_5 et_pb_toggle_item  et_pb_toggle_close">
+				
+				
+				<h2 class="et_pb_toggle_title">February 22, 2021</h2>
+				<div class="et_pb_toggle_content clearfix"><ul>
+<li><a href="https://hsr.ca.gov/wp-content/uploads/2021/03/brdmtg_022221_SM_Committee_Agenda.pdf">February 22, 2021 Special Matters Committee Meeting Agenda</a></li>
+</ul></div> <!-- .et_pb_toggle_content -->
+			</div> <!-- .et_pb_toggle -->
+			</div> <!-- .et_pb_column -->
+				
+				
+			</div> <!-- .et_pb_row_inner -->
+			</div> <!-- .et_pb_column --><div class="et_pb_column et_pb_column_1_3 et_pb_column_1    et_pb_css_mix_blend_mode_passthrough">
+				
+				
+				<div class="et_pb_module et_pb_divider et_pb_divider_0 et_pb_divider_position_ et_pb_space"><div class="et_pb_divider_internal"></div></div><div class="et_pb_module et_pb_ca_siblingPages et_pb_ca_siblingPages_0">
+				
+				
+				
+				
+				<div class="et_pb_module_inner">
+					<ul><li class="page_item page-item-9694"><a href="https://hsr.ca.gov/about/board-of-directors/board-members/">Board Members</a><li class="page_item page-item-9649"><a href="https://hsr.ca.gov/about/board-of-directors/board-resolutions/">Board Resolutions</a><li class="page_item page-item-10928"><a href="https://hsr.ca.gov/about/board-of-directors/schedule/">Board Meeting Schedule &amp; Materials</a><li class="page_item page-item-9573"><a href="https://hsr.ca.gov/about/board-of-directors/ceo-report/">CEO Report</a><li class="page_item page-item-9600"><a href="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/">Finance &amp; Audit Committee</a><li class="page_item page-item-10942"><a href="https://hsr.ca.gov/about/board-of-directors/transit-land-use-committee/">Transit &amp; Land Use Committee</a><li class="current_page_item page_item page-item-15821"><a aria-current="true" href="https://hsr.ca.gov/about/board-of-directors/special-matters-committee/">Special Matters Committee</a></ul>
+				</div>
+			</div><div class="et_pb_module et_pb_image et_pb_image_0">
+				
+				
+				<span class="et_pb_image_wrap "><img loading="lazy" src="https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb.jpg" alt="" title="" height="auto" width="auto" srcset="https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb.jpg 278w, https://hsr.ca.gov/wp-content/uploads/2020/10/bod-thumb-16x8.jpg 16w" sizes="(max-width: 278px) 100vw, 278px" class="wp-image-1484" data-pagespeed-url-hash="1929351878" onload="pagespeed.CriticalImages.checkImageForCriticality(this);"/></span>
+			</div><div class="et_pb_module et_pb_code et_pb_code_0">
+				
+				
+				<div class="et_pb_code_inner"><div class="dropdown">
+    <button class="btn btn-primary dropdown-toggle btn-block" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+        Board Meeting Materials
+    </button>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/">2022</a>
+			  <a class="dropdown-item" href="/about/board-of-directors/schedule/2021-minutes">2021</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2020-minutes">2020</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2019-minutes">2019</a>
+        <a class="dropdown-item" href="/about/board-of-directors/schedule/2018-minutes">2018</a>
+    </div>
+</div></div>
+			</div> <!-- .et_pb_code --><div class="et_pb_module et_pb_text et_pb_text_1  et_pb_text_align_left et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><h2>Board Resolutions</h2>
+<p><a href="/about/board-of-directors/board-resolutions/">View the Board Resolutions</a></p>
+<h2>Contact</h2>
+<p>Board of Directors Secretary<br/>(916) 324-1541<br/><a href="mailto:boardmembers@hsr.ca.gov">boardmembers@hsr.ca.gov</a></p>
+</div>
+			</div> <!-- .et_pb_text -->
+			</div> <!-- .et_pb_column -->
+				</div> <!-- .et_pb_row -->
+				
+			</div> <!-- .et_pb_section --><div class="et_pb_section et_pb_section_2 section-primary et_pb_with_background et_section_regular">
+				
+				
+				
+				
+					<div class="et_pb_row et_pb_row_0">
+				<div class="et_pb_column et_pb_column_4_4 et_pb_column_2  et_pb_css_mix_blend_mode_passthrough et-last-child">
+				
+				
+				<div class="et_pb_module et_pb_text et_pb_text_2  et_pb_text_align_center et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><ul class="list-inline">
+<li><a class="btn btn-secondary" href="https://registertovote.ca.gov/">Register to Vote</a></li>
+<li><a class="btn btn-secondary" href="https://www.dmv.ca.gov/portal/dmv/detail/realid">REAL ID</a></li>
+<li><a class="btn btn-secondary" href="https://www.cdph.ca.gov/covid19">COVID-19 Updates</a></li>
+<li><a class="btn btn-secondary" href="https://covid19.ca.gov/vaccines/">Vaccinate All 58</a></li>
+</ul></div>
+			</div> <!-- .et_pb_text --><div class="et_pb_module et_pb_text et_pb_text_3  et_pb_text_align_center et_pb_bg_layout_light">
+				
+				
+				<div class="et_pb_text_inner"><p>The California High-Speed Rail Authority makes every effort to ensure the website and its contents meet mandated ADA requirements as per the California State mandated Web Content Accessibility Guidelines 2.0 Level AA standard. If you are looking for a particular document not located on the California High-Speed Rail Authority website, you may make a request for the document under the Public Records Act through the Public Records Act page. If you have any questions about the website or its contents, please contact the Authority at <a href="mailto:info@hsr.ca.gov">info@hsr.ca.gov</a>.</p></div>
+			</div> <!-- .et_pb_text -->
+			</div> <!-- .et_pb_column -->
+				
+				
+			</div> <!-- .et_pb_row -->
+				
+				
+			</div> <!-- .et_pb_section -->		</div><!-- .et_builder_inner_content -->
+	</div><!-- .et-l -->
+	
+			
+		</div><!-- #et-boc -->
+		</div>
+					</article> <!-- .et_pb_post -->
+
+										<span class="return-top hidden-print"></span>
+				</main>
+			</div> <!-- #main-content -->
+		</div>
+	</div>
+	<footer id="footer" class="global-footer hidden-print"><div class="container footer-menu"><div class="group"><div class="three-quarters"><ul class="footer-links"><li><a href="#skip-to-content">Back to Top</a></li><li class="" title=""><a href="/conditions-of-use/">Conditions of Use</a></li><li class="" title=""><a href="/privacy-policy/">Privacy Policy</a></li><li class="" title=""><a href="/accessibility/">Accessibility</a></li><li class="" title=""><a href="/contact/">Contact Us</a></li><li class="" title=""><a href="/a-to-z-index/">A to Z Index</a></li></ul></div><div class="quarter"><ul class="socialsharer-container"><li><a href="https://www.facebook.com/CaliforniaHighSpeedRail/" title="Share via Facebook" target="_blank"><span class="ca-gov-icon-facebook"></span><span class="sr-only">facebook</span></a></li><li><a href="https://twitter.com/cahsra" title="Share via Twitter" target="_blank"><span class="ca-gov-icon-twitter"></span><span class="sr-only">twitter</span></a></li><li><a href="https://www.flickr.com/photos/hsrcagov/" title="Share via Flickr" target="_blank"><span class="ca-gov-icon-flickr"></span><span class="sr-only">flickr</span></a></li><li><a href="https://www.youtube.com/CAHighSpeedRail" title="Share via YouTube" target="_blank"><span class="ca-gov-icon-youtube"></span><span class="sr-only">youtube</span></a></li><li><a href="https://www.instagram.com/cahsra/" title="Share via Instagram" target="_blank"><span class="ca-gov-icon-instagram"></span><span class="sr-only">instagram</span></a></li><li><a href="https://www.linkedin.com/company/california-high-speed-rail-authority" title="Share via LinkedIn" target="_blank"><span class="ca-gov-icon-linkedin"></span><span class="sr-only">linkedin</span></a></li></ul></div></div></div><!-- Copyright Statement --><div class="copyright"><div class="container"><p class="d-inline">Copyright &copy; 2022 State of California</p></div></div></footer>        <div id="trp-floater-ls" onclick="" data-no-translation class="trp-language-switcher-container trp-floater-ls-names trp-bottom-right trp-color-dark">
+            <div id="trp-floater-ls-current-language" class="trp-with-flags">
+                <a href="#" class="trp-floater-ls-disabled-language trp-ls-disabled-language" onclick="event.preventDefault()">
+					<img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/en_US.png" width="18" height="12" alt="en_US" title="English" data-pagespeed-url-hash="2115649056" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">English				</a>
+            </div>
+            <div id="trp-floater-ls-language-list" class="trp-with-flags">
+                <div class="trp-language-wrap">                    <a href="https://hsr.ca.gov/es/about/board-of-directors/special-matters-committee/" title="Español de México">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/es_MX.png" width="18" height="12" alt="es_MX" title="Español de México" data-pagespeed-url-hash="1320759892" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Español de México					          </a>
+                                    <a href="https://hsr.ca.gov/ar/about/board-of-directors/special-matters-committee/" title="العربية">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ar.png" width="18" height="12" alt="ar" title="العربية" data-pagespeed-url-hash="2956364983" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">العربية					          </a>
+                                    <a href="https://hsr.ca.gov/hy/about/board-of-directors/special-matters-committee/" title="Հայերեն">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/hy.png" width="18" height="12" alt="hy" title="Հայերեն" data-pagespeed-url-hash="196385043" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Հայերեն					          </a>
+                                    <a href="https://hsr.ca.gov/hmn/about/board-of-directors/special-matters-committee/" title="Hmong">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/uploads/2021/05/hmong-16x10.png" width="18" height="12" alt="hmn" title="Hmong" data-pagespeed-url-hash="652958787" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Hmong					          </a>
+                                    <a href="https://hsr.ca.gov/zh/about/board-of-directors/special-matters-committee/" title="繁體中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_TW.png" width="18" height="12" alt="zh_TW" title="繁體中文" data-pagespeed-url-hash="181731812" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">繁體中文					          </a>
+                                    <a href="https://hsr.ca.gov/zh_hk/about/board-of-directors/special-matters-committee/" title="香港中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_HK.png" width="18" height="12" alt="zh_HK" title="香港中文" data-pagespeed-url-hash="1845292212" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">香港中文					          </a>
+                                    <a href="https://hsr.ca.gov/zh_cn/about/board-of-directors/special-matters-committee/" title="简体中文">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/zh_CN.png" width="18" height="12" alt="zh_CN" title="简体中文" data-pagespeed-url-hash="3104872040" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">简体中文					          </a>
+                                    <a href="https://hsr.ca.gov/ko/about/board-of-directors/special-matters-committee/" title="한국어">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ko_KR.png" width="18" height="12" alt="ko_KR" title="한국어" data-pagespeed-url-hash="2804872994" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">한국어					          </a>
+                                    <a href="https://hsr.ca.gov/ja/about/board-of-directors/special-matters-committee/" title="日本語">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/ja.png" width="18" height="12" alt="ja" title="日本語" data-pagespeed-url-hash="1567889505" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">日本語					          </a>
+                                    <a href="https://hsr.ca.gov/pa/about/board-of-directors/special-matters-committee/" title="ਪੰਜਾਬੀ">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/pa_IN.png" width="18" height="12" alt="pa_IN" title="ਪੰਜਾਬੀ" data-pagespeed-url-hash="1605722755" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">ਪੰਜਾਬੀ					          </a>
+                                    <a href="https://hsr.ca.gov/tl/about/board-of-directors/special-matters-committee/" title="Tagalog">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/tl.png" width="18" height="12" alt="tl" title="Tagalog" data-pagespeed-url-hash="4055228506" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Tagalog					          </a>
+                                    <a href="https://hsr.ca.gov/vi/about/board-of-directors/special-matters-committee/" title="Tiếng Việt">
+          						  <img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/vi.png" width="18" height="12" alt="vi" title="Tiếng Việt" data-pagespeed-url-hash="3021296717" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">Tiếng Việt					          </a>
+                <a href="#" class="trp-floater-ls-disabled-language trp-ls-disabled-language" onclick="event.preventDefault()"><img class="trp-flag-image" src="https://hsr.ca.gov/wp-content/plugins/translatepress-multilingual/assets/images/flags/en_US.png" width="18" height="12" alt="en_US" title="English" data-pagespeed-url-hash="2115649056" onload="pagespeed.CriticalImages.checkImageForCriticality(this);">English</a></div>            </div>
+        </div>
+
+    			<script>document.body.classList.remove('primary');</script>
+		<script>var $=jQuery;</script>
+
+<script src="/wp-content/custom/js/library.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.4.6/js/swiper.min.js"></script>
+<script>var swiper=new Swiper('.swiper-container',{slidesPerView:4,spaceBetween:2,loop:true,navigation:{nextEl:'.section__gallery-button--next',prevEl:'.section__gallery-button--prev',},breakpoints:{1440:{slidesPerView:3},900:{slidesPerView:2},550:{slidesPerView:1}}});</script>
+
+<script>document.addEventListener("DOMContentLoaded",function(event){document.querySelectorAll('.info-image__popup')});</script>
+
+<script type='text/javascript' id='thickbox-js-extra'>//<![CDATA[
+var thickboxL10n={"next":"Next >","prev":"< Prev","image":"Image","of":"of","close":"Close","noiframes":"This feature requires inline frames. You have iframes disabled or your browser does not support them.","loadingAnimation":"https:\/\/hsr.ca.gov\/wp-includes\/js\/thickbox\/loadingAnimation.gif"};
+//]]></script>
+<script type='text/javascript' defer src='https://hsr.ca.gov/wp-includes/js/thickbox/thickbox.js?ver=3.1-20121105' id='thickbox-js'></script>
+<script type='text/javascript' id='et-builder-modules-global-functions-script-js-extra'>//<![CDATA[
+var et_builder_utils_params={"condition":{"diviTheme":true,"extraTheme":false},"scrollLocations":["app","top"],"builderScrollLocations":{"desktop":"app","tablet":"app","phone":"app"},"onloadScrollLocation":"app","builderType":"fe"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/frontend-builder/build/frontend-builder-global-functions.js?ver=4.9.3' id='et-builder-modules-global-functions-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.mobile.custom.min.js?ver=4.9.3' id='et-jquery-touch-mobile-js'></script>
+<script type='text/javascript' id='divi-custom-script-js-extra'>//<![CDATA[
+var DIVI={"item_count":"%d Item","items_count":"%d Items"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/js/custom.js?ver=4.9.3' id='divi-custom-script-js'></script>
+<script type='text/javascript' id='et-builder-modules-script-js-extra'>//<![CDATA[
+var et_frontend_scripts={"builderCssContainerPrefix":"#et-boc","builderCssLayoutPrefix":"#et-boc .et-l"};var et_pb_custom={"ajaxurl":"https:\/\/hsr.ca.gov\/wp-admin\/admin-ajax.php","images_uri":"https:\/\/hsr.ca.gov\/wp-content\/themes\/Divi\/images","builder_images_uri":"https:\/\/hsr.ca.gov\/wp-content\/themes\/Divi\/includes\/builder\/images","et_frontend_nonce":"249d2c02fb","subscription_failed":"Please, check the fields below to make sure you entered the correct information.","et_ab_log_nonce":"7a20669850","fill_message":"Please, fill in the following fields:","contact_error_message":"Please, fix the following errors:","invalid":"Invalid email","captcha":"Captcha","prev":"Prev","previous":"Previous","next":"Next","wrong_captcha":"You entered the wrong number in captcha.","wrong_checkbox":"Checkbox","ignore_waypoints":"no","is_divi_theme_used":"1","widget_search_selector":".widget_search","ab_tests":[],"is_ab_testing_active":"","page_id":"15821","unique_test_id":"","ab_bounce_rate":"5","is_cache_plugin_active":"no","is_shortcode_tracking":"","tinymce_uri":""};var et_pb_box_shadow_elements=[];var et_pb_motion_elements={"desktop":[],"tablet":[],"phone":[]};var et_pb_sticky_elements=[];
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/frontend-builder/build/frontend-builder-scripts.js?ver=4.9.3' id='et-builder-modules-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/plugins/hsr-plugins/scripts/frontend-bundle.min.js?ver=1.0.0' id='symsoft-divi-extension-frontend-bundle-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/divi/extension/scripts/frontend-bundle.min.js?ver=1.0.0' id='caweb-module-extension-frontend-bundle-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.fitvids.js?ver=4.9.3' id='divi-fitvids-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/waypoints.min.js?ver=4.9.3' id='waypoints-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/includes/builder/scripts/ext/jquery.magnific-popup.js?ver=4.9.3' id='magnific-popup-js'></script>
+<script type='text/javascript' id='cagov-caweb-script-js-extra'>//<![CDATA[
+var args={"ca_google_analytic_id":"UA-73985215-2","ca_google_tag_manager_id":"GTM-N6J3M4W","ca_google_tag_manager_approved":"","ca_site_version":"5","ca_frontpage_search_enabled":"","ca_google_search_id":"001779225245372747843:jso5c-pvxls","caweb_multi_ga":"","ca_google_trans_enabled":"","ajaxurl":"https:\/\/hsr.ca.gov\/wp-admin\/admin-post.php"};
+//]]></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/CAWeb-1.5.0/js/caweb-v5.min.js?ver=5.7.7' id='cagov-caweb-script-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/themes/Divi/core/admin/js/common.js?ver=4.9.3' id='et-core-common-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-content/caweb-1.5.0-ext/js/1/caweb-custom.js?ver=-6340c141d9c191.36269253' id='caweb-custom-js-js'></script>
+<script type='text/javascript' src='https://hsr.ca.gov/wp-includes/js/wp-embed.js?ver=5.7.7' id='wp-embed-js'></script>
+<style id="et-builder-module-design-15821-cached-inline-styles">.et_pb_section_0.et_pb_section{padding-top:0;margin-top:0}.et_pb_column_0{padding-top:0}.et_pb_column_1{padding-top:0}.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7}.{max-width:none}.et_pb_toggle_0.et_pb_toggle h5,.et_pb_toggle_0.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_3.et_pb_toggle h5,.et_pb_toggle_3.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_4.et_pb_toggle h5,.et_pb_toggle_4.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_1.et_pb_toggle h5,.et_pb_toggle_1.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_2.et_pb_toggle h5,.et_pb_toggle_2.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_toggle_5.et_pb_toggle h5,.et_pb_toggle_5.et_pb_toggle h1.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h2.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h3.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h4.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle h6.et_pb_toggle_title{font-size:1.1rem}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-width:0 0 1px 0;border-bottom-color:#d0d3d7}.et_pb_toggle_1.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_5.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_2.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_4.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_0.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_3.et_pb_toggle{padding-left:0!important;margin-bottom:0!important}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_close{background-color:#fff}.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_0.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_3.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_2.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_1.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_4.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h5.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h1.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h2.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h3.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h4.et_pb_toggle_title,.et_pb_toggle_5.et_pb_toggle.et_pb_toggle_open h6.et_pb_toggle_title{color:#007fad!important}.et_pb_toggle_5 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_2 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_0 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_4 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_1 .et_pb_toggle_title:before{color:#007fad}.et_pb_toggle_3 .et_pb_toggle_title:before{color:#007fad}.et_pb_divider_0{background-color:#007fad;padding-top:7rem;margin-bottom:0!important}.et_pb_divider_0:before{border-top-color:#007fad;width:auto;top:7rem;right:0;left:0}.et_pb_ca_siblingPages_0{background-color:#007fad;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem;margin-bottom:0!important}.et_pb_image_0{margin-top:0!important;width:100%;max-width:100%!important;text-align:left;margin-left:0}.et_pb_image_0 .et_pb_image_wrap,.et_pb_image_0 img{width:100%}.et_pb_text_1 h2{font-weight:700;text-transform:uppercase;font-size:20px}.et_pb_section_2.et_pb_section{background-color:#22407d!important}.et_pb_text_3{max-width:630px}.et_pb_text_3.et_pb_module{margin-left:auto!important;margin-right:auto!important}@media only screen and (max-width:980px){.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_divider_0{padding-top:0}.et_pb_divider_0:before{width:auto;top:0;right:0;left:0}}@media only screen and (min-width:768px) and (max-width:980px){.et_pb_ca_breadcrumb_0{display:none!important}}@media only screen and (max-width:767px){.et_pb_ca_breadcrumb_0{border-bottom-width:1px;border-bottom-color:#d0d3d7;display:none!important}.et_pb_module.et_pb_toggle_0.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_1.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_2.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_3.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_4.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}.et_pb_module.et_pb_toggle_5.et_pb_toggle{border-bottom-width:1px;border-bottom-color:#d0d3d7}}</style>		<script>$=jQuery.noConflict();var media_carousels=$('div[class*="et_pb_ca_fullwidth_section_carousel_"]:not(".item")');media_carousels.each(function(index,carousel){if($(carousel).hasClass('media')||$(carousel).hasClass('panel')){$(carousel).find('.carousel-media').owlCarousel({responsive:true,responsive:{0:{items:1,nav:true},400:{items:1,nav:true},768:{items:undefined===carousel.slide_amount?4:carousel.slide_amount,nav:true},},margin:10,nav:true,dots:false,navText:['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>','<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'],});}})</script>
+				<script>$=jQuery.noConflict();var media_carousels=$('div[class*="et_pb_ca_section_carousel_"]:not(".item")');media_carousels.each(function(index,carousel){if($(carousel).hasClass('media')||$(carousel).hasClass('panel')){$(carousel).find('.carousel-media').owlCarousel({responsive:true,responsive:{0:{items:1,nav:true},400:{items:1,nav:true},768:{items:undefined===carousel.slide_amount?4:carousel.slide_amount,nav:true},},margin:10,nav:true,dots:false,navText:['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>','<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'],});}})</script>
+		</body>
+</html>
+
+<!--
+Performance optimized by W3 Total Cache. Learn more: https://www.boldgrid.com/w3-total-cache/
+
+Page Caching using disk: enhanced 
+
+Served from: hsr.ca.gov @ 2022-10-07 17:16:02 by W3 Total Cache
+-->

--- a/tests/test_ca_highspeed_rail.py
+++ b/tests/test_ca_highspeed_rail.py
@@ -1,0 +1,177 @@
+from datetime import datetime
+from os.path import dirname, join
+
+from city_scrapers_core.constants import BOARD, COMMITTEE, PASSED, TENTATIVE
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.ca_highspeed_rail import CaHighspeedRailSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "ca_highspeed_rail.html"),
+    url="https://hsr.ca.gov/about/board-of-directors/schedule/",
+)
+test_finance_committee_response = file_response(
+    join(dirname(__file__), "files", "ca_highspeed_rail_finance_committee.html"),
+    url="https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/",
+)
+test_special_matters_committee_response = file_response(
+    join(dirname(__file__), "files", "ca_highspeed_rail_special_committee.html"),
+    url="https://hsr.ca.gov/about/board-of-directors/special-matters-committee/",
+)
+
+spider = CaHighspeedRailSpider()
+
+freezer = freeze_time("2022-10-04")
+freezer.start()
+
+# parsed_items[0] is upcoming
+# parsed_items[3] is a past item
+parsed_items = [item for item in spider.parse(test_response)]
+parsed_items_finance_committee = [
+    item for item in spider.parse(test_finance_committee_response)
+]
+parsed_items_special_matters_committee = [
+    item for item in spider.parse(test_special_matters_committee_response)
+]
+
+freezer.stop()
+
+
+def test_title():
+    assert parsed_items[0]["title"] == "Board Meeting"
+    assert parsed_items_finance_committee[0]["title"] == "Finance & Audit Committee"
+    assert (
+        parsed_items_special_matters_committee[0]["title"]
+        == "Special Matters Committee"
+    )
+
+
+def test_description():
+    assert parsed_items[0]["description"] == ""
+    assert parsed_items[3]["description"] == ""
+    assert parsed_items_finance_committee[0]["description"] == ""
+
+
+def test_start():
+    assert parsed_items[0]["start"] == datetime(2022, 10, 20, 10, 0)
+    assert parsed_items[3]["start"] == datetime(2022, 9, 15, 10, 0)
+    assert parsed_items_finance_committee[0]["start"] == datetime(2022, 9, 15, 10, 0)
+    assert parsed_items_special_matters_committee[0]["start"] == datetime(
+        2021, 3, 29, 10, 0
+    )
+
+
+def test_end():
+    assert parsed_items[0]["end"] is None
+    assert parsed_items[3]["end"] is None
+    assert parsed_items_finance_committee[0]["end"] is None
+    assert parsed_items_special_matters_committee[0]["end"] is None
+
+
+def test_time_notes():
+    assert parsed_items[0]["time_notes"] == ""
+    assert parsed_items[3]["time_notes"] == ""
+    assert parsed_items_finance_committee[0]["time_notes"] == ""
+    assert parsed_items_special_matters_committee[0]["time_notes"] == ""
+
+
+def test_id():
+    assert parsed_items[0]["id"] == "ca_highspeed_rail/202210201000/x/board_meeting"
+    assert (
+        parsed_items_finance_committee[0]["id"]
+        == "ca_highspeed_rail/202209151000/x/finance_audit_committee"
+    )
+    assert (
+        parsed_items_special_matters_committee[0]["id"]
+        == "ca_highspeed_rail/202103291000/x/special_matters_committee"
+    )
+
+
+def test_status():
+    assert parsed_items[0]["status"] == TENTATIVE
+    assert parsed_items[3]["status"] == PASSED
+    assert parsed_items_finance_committee[0]["status"] == PASSED
+    assert parsed_items_special_matters_committee[0]["status"] == PASSED
+
+
+def test_location():
+    assert parsed_items[0]["location"] == {
+        "name": "California High-Speed Rail Authority",
+        "address": "770 L Street, Suite 620 Sacramento, CA 95814",
+    }
+
+    assert parsed_items_finance_committee[0]["location"] == {
+        "name": "California High-Speed Rail Authority",
+        "address": "770 L Street, Suite 620 Sacramento, CA 95814",
+    }
+
+    assert parsed_items_special_matters_committee[0]["location"] == {
+        "name": "California High-Speed Rail Authority",
+        "address": "770 L Street, Suite 620 Sacramento, CA 95814",
+    }
+
+
+def test_source():
+    assert (
+        parsed_items[0]["source"]
+        == "https://hsr.ca.gov/about/board-of-directors/schedule/"
+    )
+    assert (
+        parsed_items[3]["source"]
+        == "https://hsr.ca.gov/about/board-of-directors/schedule/"
+    )
+    assert (
+        parsed_items_finance_committee[0]["source"]
+        == "https://hsr.ca.gov/about/board-of-directors/finance-audit-committee/"
+    )
+    assert (
+        parsed_items_special_matters_committee[0]["source"]
+        == "https://hsr.ca.gov/about/board-of-directors/special-matters-committee/"
+    )
+
+
+def test_links():
+    # Asserting the first two items
+    assert parsed_items[0]["links"] == []
+    assert parsed_items[3]["links"][:2] == [
+        {
+            "href": "https://hsr.ca.gov/2022/09/05/board-of-directors-meeting-4/",
+            "title": "September 15, 2022 Board Meeting Agenda",
+        },
+        {
+            "href": "https://youtu.be/ShlVl2Tf6y0",
+            "title": "September 15, 2022 Board Meeting Video",
+        },
+    ]
+
+    assert parsed_items_finance_committee[0]["links"][:2] == [
+        {
+            "title": "September 15, 2022 Finance & Audit Committee Agenda",
+            "href": "https://hsr.ca.gov/2022/08/15/finance-and-audit-committee-agenda/",
+        },
+        {
+            "title": "September 15, 2022 Finance & Audit Committee Video",
+            "href": "https://youtu.be/OYerQMqeJYM",
+        },
+    ]
+
+    assert parsed_items_special_matters_committee[0]["links"] == []
+    assert parsed_items_special_matters_committee[1]["links"] == [
+        {
+            "href": "https://hsr.ca.gov/wp-content/uploads"
+            "/2021/04/brdmtg_032221_SM_Committee_Agenda.pdf",
+            "title": "March 22, 2021 Special Matters Committee Meeting Agenda",
+        }
+    ]
+
+
+def test_classification():
+    assert parsed_items[0]["classification"] == BOARD
+    assert parsed_items_finance_committee[0]["classification"] == COMMITTEE
+    assert parsed_items_special_matters_committee[0]["classification"] == COMMITTEE
+
+
+# @pytest.mark.parametrize("item", parsed_items)
+# def test_all_day(item):
+#     assert item["all_day"] is False


### PR DESCRIPTION
## Summary
Can scrape the board of directors page, finance committee and special matters.
A lots of links are usually included for each meeting in the board of directors.

<b>When scraping upcoming meetings I could find a use case were the agenda was included</b>

## Checklist
- [x] Tests are implemented
- [x] All tests are passing
- [x] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [x] Style checks are passing
- [x] Code comments from template removed
- [x] Correct timezone for scraper
