### PR TITLE
Bugfix San Diego City DateTime None

### DIFF
--- a/city_scrapers/spiders/san_diego_city.py
+++ b/city_scrapers/spiders/san_diego_city.py
@@ -227,7 +227,7 @@ class SanDiegoCitySpider(CityScrapersSpider):
         if results:
             start_str = results.group("datetime")
             if start_str:
-                start = parse(start_str, ignoretz = True)
+                start = parse(start_str, ignoretz=True)
                 return start
 
         return None
@@ -242,14 +242,14 @@ class SanDiegoCitySpider(CityScrapersSpider):
 
         if start_time:
             start_time = start_time.group().strip()
-            return parse(start_time, ignoretz = True)
+            return parse(start_time, ignoretz=True)
 
         return None
 
     def _parse_start(self, item):
         """Parse start datetime as a naive datetime object."""
         start_date_str = item.xpath(".//td[2]/text()").get()
-        start = parse(start_date_str, ignoretz = True)
+        start = parse(start_date_str, ignoretz=True)
         return start
 
     def _parse_end(self, item, start: datetime):

--- a/city_scrapers/spiders/san_diego_city.py
+++ b/city_scrapers/spiders/san_diego_city.py
@@ -91,6 +91,9 @@ class SanDiegoCitySpider(CityScrapersSpider):
                     updated=datetime.now(),
                 )
 
+                if meeting["start"] is None:
+                    return
+
                 meeting["status"] = self._get_status(meeting)
                 meeting["id"] = self._get_id(meeting)
 
@@ -136,6 +139,9 @@ class SanDiegoCitySpider(CityScrapersSpider):
                         created=datetime.now(),
                         updated=datetime.now(),
                     )
+
+                    if meeting["start"] is None:
+                        return
 
                     meeting["status"] = self._get_status(meeting)
                     meeting["id"] = self._get_id(meeting)

--- a/city_scrapers/spiders/san_diego_city.py
+++ b/city_scrapers/spiders/san_diego_city.py
@@ -227,8 +227,8 @@ class SanDiegoCitySpider(CityScrapersSpider):
         if results:
             start_str = results.group("datetime")
             if start_str:
-                start = parse(start_str)
-                return start.replace(tzinfo=None)
+                start = parse(start_str, ignoretz = True)
+                return start
 
         return None
 
@@ -242,15 +242,15 @@ class SanDiegoCitySpider(CityScrapersSpider):
 
         if start_time:
             start_time = start_time.group().strip()
-            return parse(start_time).replace(tzinfo=None)
+            return parse(start_time, ignoretz = True)
 
         return None
 
     def _parse_start(self, item):
         """Parse start datetime as a naive datetime object."""
         start_date_str = item.xpath(".//td[2]/text()").get()
-        start = parse(start_date_str)
-        return start.replace(tzinfo=None)
+        start = parse(start_date_str, ignoretz = True)
+        return start
 
     def _parse_end(self, item, start: datetime):
         """Parse end datetime as a naive datetime object. Added by pipeline if None"""


### PR DESCRIPTION
## Summary
Resolves the issue `TypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'`.  Meetings without a start time do not call `get_status`.

Also changed dateparsing to use `ignoretz` to avoid the warning on `tzinfo`

**Issue:** #45 

Replace "ISSUE_NUMBER" with the number of your issue so that GitHub will link this pull request with the issue and make review easier.

## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [x] Tests are implemented
- [x] All tests are passing
- [x] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [x] Style checks are passing
- [x] Code comments from template removed
- [x] Correct timezone for scraper

## Questions

Include any questions you have about what you're working on.
